### PR TITLE
Refactor OpenAPI handling with version-specific processors

### DIFF
--- a/apispec_aiohttp/__init__.py
+++ b/apispec_aiohttp/__init__.py
@@ -14,12 +14,17 @@ from .decorators import (
     response_schema,
 )
 from .middlewares import validation_middleware
+from .processors import BaseOpenAPIProcessor, OpenAPIv2Processor, OpenAPIv3Processor, create_processor
 
 __all__ = [
     "AiohttpApiSpec",
+    "BaseOpenAPIProcessor",
+    "OpenAPIv2Processor",
+    "OpenAPIv3Processor",
     "OpenApiVersion",
     "__version__",
     "cookies_schema",
+    "create_processor",
     "docs",
     "form_schema",
     "headers_schema",

--- a/apispec_aiohttp/core.py
+++ b/apispec_aiohttp/core.py
@@ -63,7 +63,7 @@ class AiohttpApiSpec:
         schema_name_resolver: SchemaNameResolver = resolver,
         openapi_version: str | OpenApiVersion = OpenApiVersion.V20,
         swagger_layout: LayoutOption = LayoutOption.Standalone,
-        **kwargs: Any,
+        **options: Any,
     ):
         try:
             openapi_version = OpenApiVersion(openapi_version)
@@ -72,7 +72,7 @@ class AiohttpApiSpec:
 
         # Initialize components
         self._spec_manager = SpecManager(
-            openapi_version=openapi_version.value, schema_name_resolver=schema_name_resolver, **kwargs
+            openapi_version=openapi_version.value, schema_name_resolver=schema_name_resolver, **options
         )
         self._route_processor = RouteProcessor(self._spec_manager, prefix=prefix)
         self._swagger_ui = SwaggerUIManager(url=url, static_path=static_path, layout=swagger_layout)
@@ -171,7 +171,7 @@ def setup_apispec_aiohttp(
     schema_name_resolver: SchemaNameResolver = resolver,
     openapi_version: str | OpenApiVersion = OpenApiVersion.V20,
     swagger_layout: LayoutOption = LayoutOption.Standalone,
-    **kwargs: Any,
+    **options: Any,
 ) -> AiohttpApiSpec:
     """
     apispec-aiohttp extension.
@@ -239,7 +239,7 @@ def setup_apispec_aiohttp(
     :param openapi_version: version of OpenAPI schema
     :param swagger_layout: layout of Swagger UI (``LayoutOption.Standalone`` by default).
                             See ``LayoutOption`` for more details.
-    :param kwargs: any apispec.APISpec kwargs
+    :param options: any apispec.APISpec options
     :return: return instance of AiohttpApiSpec class
     :rtype: AiohttpApiSpec
     """
@@ -257,5 +257,5 @@ def setup_apispec_aiohttp(
         schema_name_resolver=schema_name_resolver,
         openapi_version=openapi_version,
         swagger_layout=swagger_layout,
-        **kwargs,
+        **options,
     )

--- a/apispec_aiohttp/core.py
+++ b/apispec_aiohttp/core.py
@@ -149,11 +149,11 @@ class AiohttpApiSpec:
 
     @staticmethod
     def _setup_spec_endpoint(app: web.Application, spec_path: str) -> None:
-        async def swagger_handler(request: web.Request) -> web.Response:
+        async def spec_handler(request: web.Request) -> web.Response:
             return web.json_response(request.app[SWAGGER_DICT])
 
         spec_path = spec_path if spec_path.startswith("/") else f"/{spec_path}"
-        app.router.add_get(spec_path, swagger_handler, name=NAME_SWAGGER_SPEC)
+        app.router.add_get(spec_path, spec_handler, name=NAME_SWAGGER_SPEC)
 
 
 def setup_apispec_aiohttp(

--- a/apispec_aiohttp/core.py
+++ b/apispec_aiohttp/core.py
@@ -143,7 +143,7 @@ class AiohttpApiSpec:
         app.on_startup.append(_async_register)
 
     def _register(self, app: web.Application) -> None:
-        """RRegister routes and generate API spec immediately"""
+        """Register routes and generate API spec immediately"""
         self._route_processor.register_routes(app)
         app[SWAGGER_DICT] = self.swagger_dict()
 

--- a/apispec_aiohttp/processors.py
+++ b/apispec_aiohttp/processors.py
@@ -72,7 +72,7 @@ class OpenAPIv2Processor(BaseOpenAPIProcessor):
         """Helper method to add example to schema for v2."""
         if add_to_refs:
             self._spec_manager.schemas[schema_name]["example"] = example
-        else:
+        elif parameters:
             # Get the reference path from $ref field
             ref_path = parameters[0]["schema"].pop("$ref")
             # Ensure there's no duplication of #/definitions/
@@ -156,7 +156,7 @@ class OpenAPIv3Processor(BaseOpenAPIProcessor):
         """Helper method to add example to schema for v3."""
         if add_to_refs and schema_name is not None:
             self._spec_manager.schemas[schema_name]["example"] = example
-        else:
+        elif parameters:
             # Get the reference path from $ref field
             ref_path = parameters[0]["schema"].pop("$ref")
             # Ensure there's no duplication of #/definitions/

--- a/apispec_aiohttp/processors.py
+++ b/apispec_aiohttp/processors.py
@@ -20,7 +20,7 @@ class BaseOpenAPIProcessor(ABC):
         self._spec_manager = spec_manager
 
     @abstractmethod
-    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+    def get_path_method_spec(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
         """Get path operations based on OpenAPI version."""
         ...
 
@@ -28,7 +28,7 @@ class BaseOpenAPIProcessor(ABC):
 class OpenAPIv2Processor(BaseOpenAPIProcessor):
     """Processor for OpenAPI v2.x specifications."""
 
-    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+    def get_path_method_spec(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
         if method not in VALID_METHODS_OPENAPI_V2:
             return None
 
@@ -112,7 +112,7 @@ class OpenAPIv2Processor(BaseOpenAPIProcessor):
 class OpenAPIv3Processor(BaseOpenAPIProcessor):
     """Processor for OpenAPI v3.x specifications."""
 
-    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+    def get_path_method_spec(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
         if method not in VALID_METHODS_OPENAPI_V3:
             return None
 

--- a/apispec_aiohttp/processors.py
+++ b/apispec_aiohttp/processors.py
@@ -1,0 +1,207 @@
+import copy
+from abc import ABC, abstractmethod
+from typing import Any
+
+from apispec.core import VALID_METHODS_OPENAPI_V2, VALID_METHODS_OPENAPI_V3
+from apispec.ext.marshmallow import common
+
+from .spec import SpecManager
+from .typedefs import SchemaType
+from .utils import get_path_keys
+
+VALID_RESPONSE_FIELDS = {"description", "headers", "examples"}
+DEFAULT_RESPONSE_LOCATION = "json"
+
+
+class BaseOpenAPIProcessor(ABC):
+    """Base class for OpenAPI version-specific processors."""
+
+    def __init__(self, spec_manager: SpecManager):
+        self._spec_manager = spec_manager
+
+    @abstractmethod
+    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+        """Get path operations based on OpenAPI version."""
+        ...
+
+
+class OpenAPIv2Processor(BaseOpenAPIProcessor):
+    """Processor for OpenAPI v2.x specifications."""
+
+    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+        if method not in VALID_METHODS_OPENAPI_V2:
+            return None
+
+        for schema in handler_apispec.pop("schemas", []):
+            schema_instance = schema["schema"]
+            parameters = self._spec_manager.schema2parameters(
+                schema=schema_instance, location=schema["location"], **schema["options"]
+            )
+            self._add_example(schema=schema_instance, parameters=parameters, example=schema["example"])
+            handler_apispec["parameters"].extend(parameters)
+
+        # Update path keys if they are not already present in the handler_apispec
+        existing_path_keys = {p["name"] for p in handler_apispec["parameters"] if p["in"] == "path"}
+        new_path_keys = (path_key for path_key in get_path_keys(path) if path_key not in existing_path_keys)
+        new_path_params = [self._path_parameters(path_key) for path_key in new_path_keys]
+        handler_apispec["parameters"].extend(new_path_params)
+
+        # Process responses using the version-specific processor
+        if "responses" in handler_apispec:
+            handler_apispec["responses"] = self._process_responses(handler_apispec["responses"])
+
+        return copy.deepcopy(handler_apispec)
+
+    def _add_example(
+        self, schema: SchemaType, parameters: list[dict[str, Any]], example: dict[str, Any] | None
+    ) -> None:
+        """Add examples to schema or endpoint for OpenAPI v2."""
+        if not example:
+            return
+
+        schema_instance = common.resolve_schema_instance(schema)
+        schema_name = self._spec_manager.get_schema_name(schema_instance)
+        add_to_refs = example.pop("add_to_refs", False)
+
+        if schema_name and schema_name in self._spec_manager.schemas:
+            self._add_example_to_schema(schema_name, parameters, example, add_to_refs)
+
+    def _add_example_to_schema(
+        self, schema_name: str, parameters: list[dict[str, Any]], example: dict[str, Any], add_to_refs: bool
+    ) -> None:
+        """Helper method to add example to schema for v2."""
+        if add_to_refs:
+            self._spec_manager.schemas[schema_name]["example"] = example
+        else:
+            # Get the reference path from $ref field
+            ref_path = parameters[0]["schema"].pop("$ref")
+            # Ensure there's no duplication of #/definitions/
+            if "#/definitions/#/definitions/" in ref_path:
+                ref_path = ref_path.replace("#/definitions/#/definitions/", "#/definitions/")
+            parameters[0]["schema"]["allOf"] = [{"$ref": ref_path}]
+            parameters[0]["schema"]["example"] = example
+
+    def _process_responses(self, responses_data: dict[str, Any]) -> dict[str, Any]:
+        """Process response schemas for OpenAPI v2 spec."""
+        responses = {}
+        for code, actual_params in responses_data.items():
+            if "schema" in actual_params:
+                raw_parameters = self._spec_manager.schema2parameters(
+                    schema=actual_params["schema"],
+                    location=DEFAULT_RESPONSE_LOCATION,
+                    required=actual_params.get("required", False),
+                )[0]
+                updated_params = {k: v for k, v in raw_parameters.items() if k in VALID_RESPONSE_FIELDS}
+                # OpenAPI v2 specific format
+                updated_params["schema"] = actual_params["schema"]
+
+                for extra_info in ("description", "headers", "examples"):
+                    if extra_info in actual_params:
+                        updated_params[extra_info] = actual_params[extra_info]
+                responses[code] = updated_params
+            else:
+                responses[code] = actual_params
+        return responses
+
+    @staticmethod
+    def _path_parameters(path_key: str) -> dict[str, Any]:
+        """Create path parameters based on OpenAPI v2 spec."""
+        return {"in": "path", "name": path_key, "required": True, "type": "string"}
+
+
+class OpenAPIv3Processor(BaseOpenAPIProcessor):
+    """Processor for OpenAPI v3.x specifications."""
+
+    def get_path_operations(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> dict[str, Any] | None:
+        if method not in VALID_METHODS_OPENAPI_V3:
+            return None
+
+        for schema in handler_apispec.pop("schemas", []):
+            schema_instance = schema["schema"]
+            parameters = self._spec_manager.schema2parameters(
+                schema=schema_instance, location=schema["location"], **schema["options"]
+            )
+            self._add_example(schema=schema_instance, parameters=parameters, example=schema["example"])
+            handler_apispec["parameters"].extend(parameters)
+
+        # Update path keys if they are not already present in the handler_apispec
+        existing_path_keys = {p["name"] for p in handler_apispec["parameters"] if p["in"] == "path"}
+        new_path_keys = (path_key for path_key in get_path_keys(path) if path_key not in existing_path_keys)
+        new_path_params = [self._path_parameters(path_key) for path_key in new_path_keys]
+        handler_apispec["parameters"].extend(new_path_params)
+
+        # Process responses using the version-specific processor
+        if "responses" in handler_apispec:
+            handler_apispec["responses"] = self._process_responses(handler_apispec["responses"])
+
+        return copy.deepcopy(handler_apispec)
+
+    def _add_example(
+        self, schema: SchemaType, parameters: list[dict[str, Any]], example: dict[str, Any] | None
+    ) -> None:
+        """Add examples to schema or endpoint for OpenAPI v3."""
+        if not example:
+            return
+
+        schema_instance = common.resolve_schema_instance(schema)
+        schema_name = self._spec_manager.get_schema_name(schema_instance)
+        add_to_refs = example.pop("add_to_refs", False)
+
+        # In v3, we always add the example regardless of schema being in schemas
+        self._add_example_to_schema(schema_name, parameters, example, add_to_refs)
+
+    def _add_example_to_schema(
+        self, schema_name: str, parameters: list[dict[str, Any]], example: dict[str, Any], add_to_refs: bool
+    ) -> None:
+        """Helper method to add example to schema for v3."""
+        if add_to_refs and schema_name is not None:
+            self._spec_manager.schemas[schema_name]["example"] = example
+        else:
+            # Get the reference path from $ref field
+            ref_path = parameters[0]["schema"].pop("$ref")
+            # Ensure there's no duplication of #/definitions/
+            if "#/definitions/#/definitions/" in ref_path:
+                ref_path = ref_path.replace("#/definitions/#/definitions/", "#/definitions/")
+            parameters[0]["schema"]["allOf"] = [{"$ref": ref_path}]
+            parameters[0]["schema"]["example"] = example
+
+    def _process_responses(self, responses_data: dict[str, Any]) -> dict[str, Any]:
+        """Process response schemas for OpenAPI v3 spec."""
+        responses = {}
+        for code, actual_params in responses_data.items():
+            if "schema" in actual_params:
+                raw_parameters = self._spec_manager.schema2parameters(
+                    schema=actual_params["schema"],
+                    location=DEFAULT_RESPONSE_LOCATION,
+                    required=actual_params.get("required", False),
+                )[0]
+                updated_params = {k: v for k, v in raw_parameters.items() if k in VALID_RESPONSE_FIELDS}
+                # OpenAPI v3 specific content format
+                updated_params["content"] = {
+                    "application/json": {
+                        "schema": actual_params["schema"],
+                    },
+                }
+
+                for extra_info in ("description", "headers", "examples"):
+                    if extra_info in actual_params:
+                        updated_params[extra_info] = actual_params[extra_info]
+                responses[code] = updated_params
+            else:
+                responses[code] = actual_params
+        return responses
+
+    @staticmethod
+    def _path_parameters(path_key: str) -> dict[str, Any]:
+        """Create path parameters based on OpenAPI v3 spec."""
+        return {"in": "path", "name": path_key, "required": True, "schema": {"type": "string"}}
+
+
+def create_processor(spec_manager: SpecManager) -> BaseOpenAPIProcessor:
+    """Create an appropriate processor based on OpenAPI version."""
+    version = spec_manager.openapi_version
+
+    if version.major < 3:
+        return OpenAPIv2Processor(spec_manager)
+    else:
+        return OpenAPIv3Processor(spec_manager)

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -1,5 +1,5 @@
 from aiohttp import web
-from aiohttp.hdrs import METH_ALL, METH_ANY
+from aiohttp.hdrs import METH_ALL
 
 from .constants import API_SPEC_ATTR
 from .processors import create_processor
@@ -23,7 +23,7 @@ class RouteProcessor:
         for route in app.router.routes():
             # Class based views have multiple methods
             # Register each method separately
-            if is_class_based_view(route.handler) and route.method == METH_ANY:
+            if is_class_based_view(route.handler):
                 for attr in dir(route.handler):
                     if attr.upper() in METH_ALL:
                         method = attr
@@ -45,7 +45,7 @@ class RouteProcessor:
         if not url_path:
             return None
 
-        handler_apispec = getattr(handler, API_SPEC_ATTR, {})
+        handler_apispec = getattr(handler, API_SPEC_ATTR)
         full_path = self._prefix + url_path
         handler_apispec = self._processor.get_path_operations(
             path=full_path, method=method, handler_apispec=handler_apispec

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -65,12 +65,12 @@ class RouteProcessor:
 
         handler_apispec = getattr(route.handler, API_SPEC_ATTR)
         full_path = self._prefix + route.path
-        handler_apispec = self._processor.get_path_operations(
+        handler_apispec = self._processor.get_path_method_spec(
             path=full_path, method=route.method, handler_apispec=handler_apispec
         )
         if handler_apispec is None:
             # No OpenAPI data found in the handler
             return None
 
-        # Add path spec to the main spec
-        self._spec_manager.add_path(path=full_path, method=route.method, handler_apispec=handler_apispec)
+        # Add path method spec to the main spec
+        self._spec_manager.add_path_method(path=full_path, method=route.method, handler_apispec=handler_apispec)

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -72,4 +72,5 @@ class RouteProcessor:
             # No OpenAPI data found in the handler
             return None
 
+        # Add path spec to the main spec
         self._spec_manager.add_path(path=full_path, method=route.method, handler_apispec=handler_apispec)

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -113,7 +113,7 @@ class RouteProcessor:
             handler_apispec["responses"] = self._process_responses(handler_apispec["responses"])
 
         handler_apispec = copy.deepcopy(handler_apispec)
-        self._spec_manager.app_path(path=path, method=method, handler_apispec=handler_apispec)
+        self._spec_manager.add_path(path=path, method=method, handler_apispec=handler_apispec)
 
     def _process_responses(self, responses_data: dict[str, Any]) -> dict[str, Any]:
         """Process response schemas for the spec."""

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -1,3 +1,6 @@
+from collections.abc import Iterator
+from dataclasses import dataclass
+
 from aiohttp import web
 from aiohttp.hdrs import METH_ALL
 
@@ -6,6 +9,13 @@ from .processors import create_processor
 from .spec import SpecManager
 from .typedefs import HandlerType
 from .utils import get_path, is_class_based_view
+
+
+@dataclass(frozen=True, slots=True, kw_only=True)
+class RouteData:
+    method: str
+    path: str
+    handler: HandlerType
 
 
 class RouteProcessor:
@@ -18,37 +28,44 @@ class RouteProcessor:
         self._prefix = prefix
         self._processor = create_processor(spec_manager)
 
-    def register_routes(self, app: web.Application) -> None:
-        """Register all routes from the application."""
+    @staticmethod
+    def _get_implemented_methods(class_based_view: HandlerType) -> Iterator[tuple[str, HandlerType]]:
+        for m in METH_ALL:
+            method_name = m.lower()
+            if hasattr(class_based_view, method_name):
+                yield method_name, getattr(class_based_view, method_name)
+
+    def _iter_routes(self, app: web.Application) -> Iterator[RouteData]:
         for route in app.router.routes():
             # Class based views have multiple methods
-            # Register each method separately
             if is_class_based_view(route.handler):
-                for attr in dir(route.handler):
-                    if attr.upper() in METH_ALL:
-                        method = attr
-                        sub_handler = getattr(route.handler, attr)
-                        self.register_route(route=route, method=method, handler=sub_handler)
+                for method_name, method_func in self._get_implemented_methods(route.handler):
+                    path = get_path(route)
+                    if path is not None:
+                        yield RouteData(method=method_name, path=path, handler=method_func)
 
             # Function based views have a single method
             else:
-                method = route.method.lower()
-                handler = route.handler
-                self.register_route(route=route, method=method, handler=handler)
+                path = get_path(route)
+                if path is not None:
+                    method = route.method.lower()
+                    handler = route.handler
+                    yield RouteData(method=method, path=path, handler=handler)
 
-    def register_route(self, *, route: web.AbstractRoute, method: str, handler: HandlerType) -> None:
+    def register_routes(self, app: web.Application) -> None:
+        """Register all routes from the application."""
+        for route in self._iter_routes(app):
+            self.register_route(route)
+
+    def register_route(self, route: RouteData) -> None:
         """Register a single route."""
-        if not hasattr(handler, API_SPEC_ATTR):
+        if not hasattr(route.handler, API_SPEC_ATTR):
             return None
 
-        url_path = get_path(route)
-        if not url_path:
-            return None
-
-        handler_apispec = getattr(handler, API_SPEC_ATTR)
-        full_path = self._prefix + url_path
+        handler_apispec = getattr(route.handler, API_SPEC_ATTR)
+        full_path = self._prefix + route.path
         handler_apispec = self._processor.get_path_operations(
-            path=full_path, method=method, handler_apispec=handler_apispec
+            path=full_path, method=route.method, handler_apispec=handler_apispec
         )
         if handler_apispec is not None:
-            self._spec_manager.add_path(path=full_path, method=method, handler_apispec=handler_apispec)
+            self._spec_manager.add_path(path=full_path, method=route.method, handler_apispec=handler_apispec)

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -60,6 +60,7 @@ class RouteProcessor:
     def register_route(self, route: RouteData) -> None:
         """Register a single route."""
         if not hasattr(route.handler, API_SPEC_ATTR):
+            # No OpenAPI data found in the handler
             return None
 
         handler_apispec = getattr(route.handler, API_SPEC_ATTR)
@@ -67,5 +68,8 @@ class RouteProcessor:
         handler_apispec = self._processor.get_path_operations(
             path=full_path, method=route.method, handler_apispec=handler_apispec
         )
-        if handler_apispec is not None:
-            self._spec_manager.add_path(path=full_path, method=route.method, handler_apispec=handler_apispec)
+        if handler_apispec is None:
+            # No OpenAPI data found in the handler
+            return None
+
+        self._spec_manager.add_path(path=full_path, method=route.method, handler_apispec=handler_apispec)

--- a/apispec_aiohttp/route_processor.py
+++ b/apispec_aiohttp/route_processor.py
@@ -1,61 +1,22 @@
-import copy
-from typing import Any
-
 from aiohttp import web
 from aiohttp.hdrs import METH_ALL, METH_ANY
-from apispec.core import VALID_METHODS_OPENAPI_V2
-from apispec.ext.marshmallow import common
 
 from .constants import API_SPEC_ATTR
+from .processors import create_processor
 from .spec import SpecManager
-from .typedefs import HandlerType, SchemaType
-from .utils import get_path, get_path_keys, is_class_based_view
-
-VALID_RESPONSE_FIELDS = {"description", "headers", "examples"}
-DEFAULT_RESPONSE_LOCATION = "json"
+from .typedefs import HandlerType
+from .utils import get_path, is_class_based_view
 
 
 class RouteProcessor:
     """Processes aiohttp routes to extract OpenAPI data."""
 
-    __slots__ = ("_prefix", "_spec_manager")
+    __slots__ = ("_prefix", "_processor", "_spec_manager")
 
     def __init__(self, spec_manager: SpecManager, prefix: str = ""):
         self._spec_manager = spec_manager
         self._prefix = prefix
-
-    def schema2parameters(self, *, schema: SchemaType, location: str, **kwargs: Any) -> list[dict[str, Any]]:
-        """Convert a schema to OpenAPI parameters."""
-        return self._spec_manager.schema2parameters(schema, location=location, **kwargs)
-
-    def add_example(
-        self, *, schema: SchemaType, parameters: list[dict[str, Any]], example: dict[str, Any] | None
-    ) -> None:
-        """Add examples to schema or endpoint."""
-        if not example:
-            return
-
-        schema_instance = common.resolve_schema_instance(schema)
-        schema_name = self._spec_manager.get_schema_name(schema_instance)
-        add_to_refs = example.pop("add_to_refs", False)  # Default to False if key doesn't exist
-
-        def _add_to_endpoint_or_ref() -> None:
-            if add_to_refs and schema_name is not None:
-                self._spec_manager.schemas[schema_name]["example"] = example
-            else:
-                # Get the reference path from $ref field
-                ref_path = parameters[0]["schema"].pop("$ref")
-                # Ensure there's no duplication of #/definitions/
-                if "#/definitions/#/definitions/" in ref_path:
-                    ref_path = ref_path.replace("#/definitions/#/definitions/", "#/definitions/")
-                parameters[0]["schema"]["allOf"] = [{"$ref": ref_path}]
-                parameters[0]["schema"]["example"] = example
-
-        if self._spec_manager.openapi_version.major < 3:
-            if schema_name and schema_name in self._spec_manager.schemas:
-                _add_to_endpoint_or_ref()
-        else:
-            _add_to_endpoint_or_ref()
+        self._processor = create_processor(spec_manager)
 
     def register_routes(self, app: web.Application) -> None:
         """Register all routes from the application."""
@@ -84,60 +45,10 @@ class RouteProcessor:
         if not url_path:
             return None
 
-        handle_apispec = getattr(handler, API_SPEC_ATTR, {})
-        self.update_paths(path=self._prefix + url_path, method=method, handler_apispec=handle_apispec)
-
-    def update_paths(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> None:
-        """Update spec paths with route information."""
-        if method not in VALID_METHODS_OPENAPI_V2:
-            return None
-
-        for schema in handler_apispec.pop("schemas", []):
-            schema_instance = schema["schema"]
-            parameters = self.schema2parameters(
-                schema=schema_instance, location=schema["location"], **schema["options"]
-            )
-            self.add_example(schema=schema_instance, parameters=parameters, example=schema["example"])
-            handler_apispec["parameters"].extend(parameters)
-
-        # Update path keys if they are not already present in the handler_apispec
-        existing_path_keys = {p["name"] for p in handler_apispec["parameters"] if p["in"] == "path"}
-        new_path_keys = (path_key for path_key in get_path_keys(path) if path_key not in existing_path_keys)
-        new_path_keys_params = [
-            {"in": "path", "name": path_key, "required": True, "type": "string"} for path_key in new_path_keys
-        ]
-        handler_apispec["parameters"].extend(new_path_keys_params)
-
-        #
-        if "responses" in handler_apispec:
-            handler_apispec["responses"] = self._process_responses(handler_apispec["responses"])
-
-        handler_apispec = copy.deepcopy(handler_apispec)
-        self._spec_manager.add_path(path=path, method=method, handler_apispec=handler_apispec)
-
-    def _process_responses(self, responses_data: dict[str, Any]) -> dict[str, Any]:
-        """Process response schemas for the spec."""
-        responses = {}
-        for code, actual_params in responses_data.items():
-            if "schema" in actual_params:
-                raw_parameters = self.schema2parameters(
-                    schema=actual_params["schema"],
-                    location=DEFAULT_RESPONSE_LOCATION,
-                    required=actual_params.get("required", False),
-                )[0]
-                updated_params = {k: v for k, v in raw_parameters.items() if k in VALID_RESPONSE_FIELDS}
-                if self._spec_manager.openapi_version.major < 3:
-                    updated_params["schema"] = actual_params["schema"]
-                else:
-                    updated_params["content"] = {
-                        "application/json": {
-                            "schema": actual_params["schema"],
-                        },
-                    }
-                for extra_info in ("description", "headers", "examples"):
-                    if extra_info in actual_params:
-                        updated_params[extra_info] = actual_params[extra_info]
-                responses[code] = updated_params
-            else:
-                responses[code] = actual_params
-        return responses
+        handler_apispec = getattr(handler, API_SPEC_ATTR, {})
+        full_path = self._prefix + url_path
+        handler_apispec = self._processor.get_path_operations(
+            path=full_path, method=method, handler_apispec=handler_apispec
+        )
+        if handler_apispec is not None:
+            self._spec_manager.add_path(path=full_path, method=method, handler_apispec=handler_apispec)

--- a/apispec_aiohttp/spec.py
+++ b/apispec_aiohttp/spec.py
@@ -43,7 +43,7 @@ class SpecManager:
         """Returns swagger spec representation in JSON format"""
         return self._spec.to_dict()
 
-    def add_path(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> None:
+    def add_path_method(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> None:
         """Add a new path to the spec."""
         self._spec.path(path=path, operations={method: handler_apispec})
 

--- a/apispec_aiohttp/spec.py
+++ b/apispec_aiohttp/spec.py
@@ -8,7 +8,11 @@ from .typedefs import SchemaNameResolver, SchemaType
 
 
 class SpecManager:
-    """Manages the OpenAPI specification creation and manipulation."""
+    """Manages the OpenAPI specification creation and manipulation.
+
+    :param options: Optional top-level keys
+        See https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md#openapi-object
+    """
 
     __slots__ = ("_plugin", "_spec")
 
@@ -16,13 +20,13 @@ class SpecManager:
         self,
         openapi_version: str,
         schema_name_resolver: SchemaNameResolver,
-        **kwargs: Any,
+        **options: Any,
     ):
         self._plugin = MarshmallowPlugin(schema_name_resolver=schema_name_resolver)
         self._spec = APISpec(
             plugins=(self._plugin,),
             openapi_version=openapi_version,
-            **kwargs,
+            **options,
         )
 
     @property

--- a/apispec_aiohttp/spec.py
+++ b/apispec_aiohttp/spec.py
@@ -1,7 +1,6 @@
 from typing import Any
 
 from apispec import APISpec
-from apispec.core import Components
 from apispec.ext.marshmallow import MarshmallowPlugin
 from packaging.version import Version
 
@@ -40,17 +39,9 @@ class SpecManager:
         """Returns swagger spec representation in JSON format"""
         return self._spec.to_dict()
 
-    def app_path(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> None:
+    def add_path(self, *, path: str, method: str, handler_apispec: dict[str, Any]) -> None:
         """Add a new path to the spec."""
         self._spec.path(path=path, operations={method: handler_apispec})
-
-    @property
-    def components(self) -> Components:
-        """Get access to spec components.
-
-        This is a wrapper around the spec.components property.
-        """
-        return self._spec.components
 
     @property
     def schemas(self) -> dict[str, dict[str, Any]]:

--- a/example/src/app.py
+++ b/example/src/app.py
@@ -2,7 +2,7 @@
 
 from aiohttp import web
 
-from apispec_aiohttp import setup_apispec_aiohttp, validation_middleware
+from apispec_aiohttp import OpenApiVersion, setup_apispec_aiohttp, validation_middleware
 from apispec_aiohttp.swagger_ui import LayoutOption
 
 from .routes import setup_routes
@@ -16,7 +16,12 @@ def create_app() -> web.Application:
     app["users"] = {}
 
     setup_apispec_aiohttp(
-        app, title="User API", version="0.0.1", swagger_path="/api/docs", swagger_layout=LayoutOption.Standalone
+        app,
+        title="User API",
+        version="0.0.1",
+        swagger_path="/api/docs",
+        swagger_layout=LayoutOption.Standalone,
+        openapi_version=OpenApiVersion.V20,
     )
     app.middlewares.append(validation_middleware)
 


### PR DESCRIPTION
Improves the architecture for handling different OpenAPI versions by:
- Introducing `BaseOpenAPIProcessor` abstract class with version-specific implementations
- Moving version-dependent logic from RouteProcessor to dedicated processor classes
- Using a function-based factory pattern for processor instantiation
- Simplifying RouteProcessor to delegate version-specific operations

This change enhances maintainability and makes it easier to support additional OpenAPI versions in the future.