### PR TITLE
ci: add Python 3.14 support and schedule workflow to run weekly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,9 @@ on:
   push:
     branches: [ 'master' ]
   pull_request:
+  schedule:
+    # Run every Monday at 9:00 AM UTC
+    - cron: '0 9 * * 1'
 
 # one running workflow per branch, others will wait
 concurrency: ${{ github.ref }}
@@ -25,7 +28,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v5
       - name: Install the latest version of uv
@@ -46,7 +49,7 @@ jobs:
       - mypy
     strategy:
       matrix:
-        python-version: [ '3.10', '3.11', '3.12', '3.13' ]
+        python-version: [ '3.10', '3.11', '3.12', '3.13', '3.14' ]
     steps:
       - uses: actions/checkout@v5
       - name: Install the latest version of uv


### PR DESCRIPTION
This pull request updates the CI workflow configuration to improve test coverage and automation. The main changes include adding scheduled runs and expanding Python version support.

**CI workflow enhancements:**

* Added a scheduled job to run the CI workflow every Monday at 9:00 AM UTC, ensuring regular automated checks even without new code changes.

**Python version support:**

* Updated the test and type-checking matrix to include Python 3.14, allowing the workflow to validate compatibility with the latest Python release. [[1]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL28-R31) [[2]](diffhunk://#diff-b803fcb7f17ed9235f1e5cb1fcd2f5d3b2838429d4368ae4c57ce4436577f03fL49-R52)