### PR TITLE
Fix: Prevent spurious "Multiple schemas provided" warning on falsy data

### DIFF
--- a/aiohttp_apigami/middlewares.py
+++ b/aiohttp_apigami/middlewares.py
@@ -72,10 +72,10 @@ async def validation_middleware(request: web.Request, handler: Handler) -> web.S
             request[sch.put_into] = data
 
         # Otherwise, store the validated data in the default key
-        elif data and result is _missing:
+        elif result is _missing:
             result = data
         else:
-            logger.error("Multiple schemas provided, but no put_into specified. Using the first one only.")
+            logger.warning("Multiple schemas provided, but no put_into specified. Using the first one only.")
 
     # For backward compatibility, if no validated data is provided, use the list
     result = [] if result is _missing else result

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -317,7 +317,7 @@ async def test_middleware_multiple_schemas_without_put_into(
     client = await aiohttp_client(app)
 
     # Set caplog level to capture all logs
-    caplog.set_level(logging.ERROR)
+    caplog.set_level(logging.WARNING)
 
     # Test with different values in JSON vs querystring
     json_data = {"id": 1, "name": "json_name"}
@@ -337,6 +337,39 @@ async def test_middleware_multiple_schemas_without_put_into(
 
     # Verify the warning was logged about multiple schemas
     assert "Multiple schemas provided, but no put_into specified. Using the first one only." in caplog.text
+
+
+async def test_middleware_single_schema_empty_data_no_spurious_warning(
+    aiohttp_client: AiohttpClient, caplog: pytest.LogCaptureFixture
+) -> None:
+    """Test that a single schema with empty data does not trigger a spurious 'Multiple schemas' warning."""
+
+    @request_schema(RequestSchema, location="querystring")
+    async def test_handler(request: web.Request) -> web.Response:
+        data = request["data"]
+        return web.json_response({"result": data})
+
+    app = web.Application()
+    setup_aiohttp_apispec(
+        app=app,
+        title="Test API",
+        version="0.0.1",
+    )
+    app.middlewares.append(validation_middleware)
+    app.router.add_get("/test", test_handler)
+
+    client = await aiohttp_client(app)
+    caplog.set_level(logging.WARNING)
+
+    # Send request with no querystring parameters so validated data is {}
+    resp = await client.get("/test")
+
+    assert resp.status == 200
+    result = await resp.json()
+    assert result["result"] == {}
+
+    # No "Multiple schemas" warning should appear
+    assert "Multiple schemas provided" not in caplog.text
 
 
 async def test_middleware_with_class_based_view(aiohttp_app: Any) -> None:


### PR DESCRIPTION
## Summary
Fix a logic bug in the validation middleware that caused a spurious "Multiple schemas provided" error log even when only a single `@request_schema` was used, whenever the validated data was falsy (e.g. `{}` from an empty querystring).

## Changes
- **Fix condition in `validation_middleware`** (`middlewares.py`): Remove the `data` truthiness check from `elif data and result is _missing:` so the first schema always captures its result, even when data is `{}`
- **Downgrade log level** (`middlewares.py`): Change `logger.error(...)` to `logger.warning(...)` since multiple schemas without `put_into` is a developer configuration issue, not a runtime failure
- **Update existing test** (`test_web_app.py`): Adjust `caplog.set_level` from `ERROR` to `WARNING` to match the new log level
- **Add regression test** (`test_web_app.py`): `test_middleware_single_schema_empty_data_no_spurious_warning` verifies that a single schema with empty querystring data does not trigger the warning