### PR TITLE
Feat: Add generate_spec option to disable OpenAPI spec generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- `generate_spec` option on `setup_aiohttp_apispec` / `AiohttpApiSpec` to disable OpenAPI spec generation while keeping `validation_middleware` working. Defaults to the `APIGAMI_GENERATE_SPEC` env var (truthy `1`/`true`/`yes`/`on`, falsy `0`/`false`/`no`/`off`, case-insensitive), falling back to enabled. When disabled, route scanning, spec building, the spec endpoint, and Swagger UI mount are all skipped. Resolves [#110](https://github.com/anna-money/aiohttp-apigami/issues/110).

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ When disabled:
 - Spec endpoint (`url`) is not registered
 - Swagger UI (`swagger_path`) is not mounted
 - Route scanning and spec building are skipped
-- `validation_middleware` still works — the webargs parser and validated data key are still configured
+- `validation_middleware` still works — the webargs parser, validated data key, and `error_callback` are still configured
 
 ### Testing example
 

--- a/README.md
+++ b/README.md
@@ -416,6 +416,53 @@ setup_aiohttp_apispec(app, swagger_path="/docs")
 
 Then navigate to `/docs` in your browser to see the interactive API documentation.
 
+## 🚫 Disabling Spec Generation
+
+You can disable OpenAPI spec generation entirely while keeping request validation working. Useful for tests or production deployments where Swagger UI and the spec endpoint are not needed (skips route scanning, spec building, swagger endpoint, and Swagger UI mounting — typically saves ~20ms per app startup).
+
+Disable via the `generate_spec` parameter:
+
+```python
+setup_aiohttp_apispec(
+    app=app,
+    generate_spec=False,  # skip spec/UI; validation_middleware still works
+)
+```
+
+Or via the `APIGAMI_GENERATE_SPEC` environment variable (used when `generate_spec` is not passed):
+
+```bash
+APIGAMI_GENERATE_SPEC=0 python -m myapp
+```
+
+Accepted env values (case-insensitive): `1`/`true`/`yes`/`on` enable, `0`/`false`/`no`/`off` disable. Invalid values fall back to the default (enabled). An explicit `generate_spec=True`/`False` argument always overrides the env var.
+
+When disabled:
+- Spec endpoint (`url`) is not registered
+- Swagger UI (`swagger_path`) is not mounted
+- Route scanning and spec building are skipped
+- `validation_middleware` still works — the webargs parser and validated data key are still configured
+
+### Testing example
+
+Replaces the `patch("AiohttpApiSpec._register")` workaround for tests that don't need OpenAPI:
+
+```python
+import pytest
+from aiohttp import web
+from aiohttp_apigami import setup_aiohttp_apispec, validation_middleware
+
+
+@pytest.fixture
+def app():
+    app = web.Application()
+    app.middlewares.append(validation_middleware)
+    setup_aiohttp_apispec(app, generate_spec=False)
+    return app
+```
+
+Or set `APIGAMI_GENERATE_SPEC=0` in your test runner's environment to disable globally without changing app setup.
+
 ## 🔄 Updating Swagger UI
 
 This package includes Swagger UI <!-- SWAGGER_UI_VERSION_START -->[v5.32.1](https://github.com/swagger-api/swagger-ui/releases/tag/v5.32.1)<!-- SWAGGER_UI_VERSION_END -->.

--- a/README.md
+++ b/README.md
@@ -418,7 +418,7 @@ Then navigate to `/docs` in your browser to see the interactive API documentatio
 
 ## 🚫 Disabling Spec Generation
 
-You can disable OpenAPI spec generation entirely while keeping request validation working. Useful for tests or production deployments where Swagger UI and the spec endpoint are not needed (skips route scanning, spec building, swagger endpoint, and Swagger UI mounting — typically saves ~20ms per app startup).
+You can disable OpenAPI spec generation entirely while keeping request validation working. Useful for tests or production deployments where Swagger UI and the spec endpoint are not needed (skips route scanning, spec building, swagger endpoint, and Swagger UI mounting — saves startup work, especially noticeable with many routes).
 
 Disable via the `generate_spec` parameter:
 

--- a/aiohttp_apigami/core.py
+++ b/aiohttp_apigami/core.py
@@ -28,6 +28,11 @@ def _resolve_generate_spec(generate_spec: bool | None) -> bool:
     Unset or invalid → default True.
     """
     if generate_spec is not None:
+        if not isinstance(generate_spec, bool):
+            raise TypeError(
+                f"generate_spec must be bool or None, got {type(generate_spec).__name__}. "
+                f"For string-based config, use the {_ENV_VAR} env var instead."
+            )
         return generate_spec
     raw = os.environ.get(_ENV_VAR)
     if raw is None:

--- a/aiohttp_apigami/core.py
+++ b/aiohttp_apigami/core.py
@@ -1,5 +1,6 @@
 import enum
 import logging.config
+import os
 from typing import Any
 
 from aiohttp import web
@@ -14,6 +15,29 @@ from .swagger_ui import NAME_SWAGGER_SPEC, LayoutOption, SwaggerUIManager
 from .typedefs import SchemaNameResolver, SchemaType
 
 logger = logging.getLogger(__name__)
+
+_ENV_VAR = "APIGAMI_GENERATE_SPEC"
+_TRUTHY = frozenset({"1", "true", "yes", "on"})
+_FALSY = frozenset({"0", "false", "no", "off"})
+
+
+def _resolve_generate_spec(generate_spec: bool | None) -> bool:
+    """Resolve generate_spec from explicit param or APIGAMI_GENERATE_SPEC env var.
+
+    Explicit param wins. Env var parsed case-insensitive: truthy → True, falsy → False.
+    Unset or invalid → default True.
+    """
+    if generate_spec is not None:
+        return generate_spec
+    raw = os.environ.get(_ENV_VAR)
+    if raw is None:
+        return True
+    value = raw.strip().lower()
+    if value in _TRUTHY:
+        return True
+    if value in _FALSY:
+        return False
+    return True
 
 
 def resolver(schema: SchemaType) -> str:
@@ -45,6 +69,7 @@ class OpenApiVersion(str, enum.Enum):
 
 class AiohttpApiSpec:
     __slots__ = (
+        "_generate_spec",
         "_registered",
         "_request_data_name",
         "_route_processor",
@@ -70,6 +95,7 @@ class AiohttpApiSpec:
         schema_name_resolver: SchemaNameResolver = resolver,
         openapi_version: str | OpenApiVersion = OpenApiVersion.V20,
         swagger_layout: LayoutOption = LayoutOption.Standalone,
+        generate_spec: bool | None = None,
         **options: Any,
     ):
         try:
@@ -94,6 +120,7 @@ class AiohttpApiSpec:
         self.prefix = prefix
         self._registered = False
         self._request_data_name = request_data_name
+        self._generate_spec = _resolve_generate_spec(generate_spec)
 
         # Register app if provided
         if app is not None:
@@ -115,12 +142,18 @@ class AiohttpApiSpec:
             logger.warning("API spec is already registered. Skipping registration.")
             return None
 
-        # Set up app configuration
+        # Set up app configuration — always done so validation_middleware works
+        # even when spec generation is disabled
         app[APISPEC_VALIDATED_DATA_NAME] = self._request_data_name
         app[APISPEC_PARSER] = parser
 
         if self.error_callback:
             parser.error_callback = self.error_callback
+
+        if not self._generate_spec:
+            # Skip route scanning, spec build, swagger endpoint, and Swagger UI
+            self._registered = True
+            return None
 
         # Register routes and generate API spec
         if in_place:
@@ -175,6 +208,7 @@ def setup_aiohttp_apispec(
     schema_name_resolver: SchemaNameResolver = resolver,
     openapi_version: str | OpenApiVersion = OpenApiVersion.V20,
     swagger_layout: LayoutOption = LayoutOption.Standalone,
+    generate_spec: bool | None = None,
     **options: Any,
 ) -> AiohttpApiSpec:
     """
@@ -243,6 +277,17 @@ def setup_aiohttp_apispec(
     :param openapi_version: version of OpenAPI schema
     :param swagger_layout: layout of Swagger UI (``LayoutOption.Standalone`` by default).
                             See ``LayoutOption`` for more details.
+    :param generate_spec: when ``False``, skip route scanning, OpenAPI spec
+                          building, swagger.json endpoint, and Swagger UI mount.
+                          The parser and ``request_data_name`` are still
+                          registered, so ``validation_middleware`` keeps working.
+                          When ``None`` (default), the value is read from the
+                          ``APIGAMI_GENERATE_SPEC`` env var (truthy
+                          ``1``/``true``/``yes``/``on`` enables, falsy
+                          ``0``/``false``/``no``/``off`` disables,
+                          case-insensitive). Unset or invalid env values fall
+                          back to ``True``. An explicit boolean always wins
+                          over the env var.
     :param options: any apispec.APISpec options
     :return: return instance of AiohttpApiSpec class
     :rtype: AiohttpApiSpec
@@ -261,5 +306,6 @@ def setup_aiohttp_apispec(
         schema_name_resolver=schema_name_resolver,
         openapi_version=openapi_version,
         swagger_layout=swagger_layout,
+        generate_spec=generate_spec,
         **options,
     )

--- a/aiohttp_apigami/core.py
+++ b/aiohttp_apigami/core.py
@@ -37,6 +37,14 @@ def _resolve_generate_spec(generate_spec: bool | None) -> bool:
         return True
     if value in _FALSY:
         return False
+    logger.warning(
+        "%s=%r is not a recognized boolean; defaulting to True. "
+        "Accepted values (case-insensitive): %s for True, %s for False.",
+        _ENV_VAR,
+        raw,
+        sorted(_TRUTHY),
+        sorted(_FALSY),
+    )
     return True
 
 

--- a/docs/plans/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/2026-05-12-disable-openapi-spec-generation.md
@@ -36,17 +36,17 @@ Resolves anna-money/aiohttp-apigami#110.
 - Modify: `aiohttp_apigami/core.py`
 - Modify: `tests/test_register.py`
 
-- [ ] Add `_ENV_VAR = "APIGAMI_GENERATE_SPEC"` constant and helper `_resolve_generate_spec(generate_spec: bool | None) -> bool` — returns `generate_spec` if not None, else parses env var (truthy/falsy strings), defaults to `True` when unset or invalid
-- [ ] Add `generate_spec: bool | None = None` kwarg to `AiohttpApiSpec.__init__`; add `_generate_spec` to `__slots__` and store resolved value
-- [ ] In `register()`: always set `app[APISPEC_VALIDATED_DATA_NAME]`, `app[APISPEC_PARSER]`, and `parser.error_callback` (so `validation_middleware` works); when `self._generate_spec is False`, skip `_register` / `_register_on_startup`, skip `_setup_spec_endpoint`, skip swagger UI setup; set `self._registered = True` and return
-- [ ] Add `generate_spec: bool | None = None` kwarg to `setup_aiohttp_apispec` and forward to `AiohttpApiSpec`
-- [ ] Update docstring on `setup_aiohttp_apispec` to document `generate_spec` semantics and `APIGAMI_GENERATE_SPEC` env var fallback
-- [ ] Write tests in `tests/test_register.py`:
+- [x] Add `_ENV_VAR = "APIGAMI_GENERATE_SPEC"` constant and helper `_resolve_generate_spec(generate_spec: bool | None) -> bool` — returns `generate_spec` if not None, else parses env var (truthy/falsy strings), defaults to `True` when unset or invalid
+- [x] Add `generate_spec: bool | None = None` kwarg to `AiohttpApiSpec.__init__`; add `_generate_spec` to `__slots__` and store resolved value
+- [x] In `register()`: always set `app[APISPEC_VALIDATED_DATA_NAME]`, `app[APISPEC_PARSER]`, and `parser.error_callback` (so `validation_middleware` works); when `self._generate_spec is False`, skip `_register` / `_register_on_startup`, skip `_setup_spec_endpoint`, skip swagger UI setup; set `self._registered = True` and return
+- [x] Add `generate_spec: bool | None = None` kwarg to `setup_aiohttp_apispec` and forward to `AiohttpApiSpec`
+- [x] Update docstring on `setup_aiohttp_apispec` to document `generate_spec` semantics and `APIGAMI_GENERATE_SPEC` env var fallback
+- [x] Write tests in `tests/test_register.py`:
   - `generate_spec=False` skips swagger spec route and `SWAGGER_DICT` population
   - `generate_spec=False` still configures `APISPEC_PARSER` + `APISPEC_VALIDATED_DATA_NAME` so middleware works
   - `generate_spec=False` + `swagger_path` does not register Swagger UI routes
   - Default (`generate_spec=None`, env unset) behaves identically to current behavior
-- [ ] Run project test suite — must pass before task 2
+- [x] Run project test suite — must pass before task 2
 
 ### Task 2: Env var fallback support
 

--- a/docs/plans/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/2026-05-12-disable-openapi-spec-generation.md
@@ -53,14 +53,14 @@ Resolves anna-money/aiohttp-apigami#110.
 **Files:**
 - Modify: `tests/test_register.py`
 
-- [ ] Confirm `_resolve_generate_spec` reads env var only when param is `None`; explicit `generate_spec=True` or `generate_spec=False` always wins
-- [ ] Add tests using `monkeypatch.setenv`:
+- [x] Confirm `_resolve_generate_spec` reads env var only when param is `None`; explicit `generate_spec=True` or `generate_spec=False` always wins
+- [x] Add tests using `monkeypatch.setenv`:
   - `APIGAMI_GENERATE_SPEC=0` disables when param omitted
   - `APIGAMI_GENERATE_SPEC=false` disables (case-insensitive)
   - `APIGAMI_GENERATE_SPEC=1` enables (same as default)
   - Explicit `generate_spec=True` overrides `APIGAMI_GENERATE_SPEC=0`
   - Invalid env value (e.g. `maybe`) falls back to default `True`
-- [ ] Run test suite — must pass before task 3
+- [x] Run test suite — must pass before task 3
 
 ### Task 3: Documentation
 

--- a/docs/plans/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/2026-05-12-disable-openapi-spec-generation.md
@@ -67,8 +67,8 @@ Resolves anna-money/aiohttp-apigami#110.
 **Files:**
 - Modify: `README.md`
 
-- [ ] Add short section near "Setup Function" / quickstart describing `generate_spec` parameter and `APIGAMI_GENERATE_SPEC` env var, with testing example replacing the `patch("AiohttpApiSpec._register")` workaround from the issue
-- [ ] Run test suite — must pass before task 4
+- [x] Add short section near "Setup Function" / quickstart describing `generate_spec` parameter and `APIGAMI_GENERATE_SPEC` env var, with testing example replacing the `patch("AiohttpApiSpec._register")` workaround from the issue
+- [x] Run test suite — must pass before task 4
 
 ### Task 4: Verify acceptance criteria
 

--- a/docs/plans/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/2026-05-12-disable-openapi-spec-generation.md
@@ -72,9 +72,9 @@ Resolves anna-money/aiohttp-apigami#110.
 
 ### Task 4: Verify acceptance criteria
 
-- [ ] Run full test suite (`make test` or `pytest`)
-- [ ] Run linter (`make lint` or configured pre-commit)
-- [ ] Verify coverage on new branches in `core.py` exercised (target 80%+ overall, 100% on new code paths)
+- [x] Run full test suite (`make test` or `pytest`)
+- [x] Run linter (`make lint` or configured pre-commit)
+- [x] Verify coverage on new branches in `core.py` exercised (target 80%+ overall, 100% on new code paths)
 
 ### Task 5: Finalize
 

--- a/docs/plans/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/2026-05-12-disable-openapi-spec-generation.md
@@ -1,0 +1,82 @@
+# Add explicit option to disable OpenAPI spec generation
+
+## Overview
+
+Add user-friendly way to disable OpenAPI spec generation in aiohttp-apigami. Controlled via `generate_spec` parameter on `setup_aiohttp_apispec` / `AiohttpApiSpec`, with `APIGAMI_GENERATE_SPEC` environment variable as fallback default. When disabled, skip route scanning, spec building, swagger endpoint, and Swagger UI mounting — keep parser registration so `validation_middleware` still works.
+
+Resolves anna-money/aiohttp-apigami#110.
+
+## Context
+
+- Files involved:
+  - `aiohttp_apigami/core.py` — `AiohttpApiSpec.__init__`, `register`, `_register`, `setup_aiohttp_apispec`
+  - `aiohttp_apigami/__init__.py` — re-exports (no public symbol change expected)
+  - `tests/test_register.py` — register tests, add disabled cases
+  - `README.md` — document new option
+- Related patterns:
+  - Boolean kwargs on `setup_aiohttp_apispec` (e.g. `in_place`)
+  - `validation_middleware` depends on `app[APISPEC_PARSER]` + `app[APISPEC_VALIDATED_DATA_NAME]` set in `register`
+  - Issue workaround patches `_register` to skip on every startup (~22ms savings per test)
+- Dependencies: stdlib `os` for env var read
+
+## Development Approach
+
+- Testing approach: Regular (code first, then tests)
+- Complete each task fully before moving to next
+- Backwards-compatible default: `generate_spec=True`
+- Env var name: `APIGAMI_GENERATE_SPEC` (truthy `1`/`true`/`yes`/`on` case-insensitive → enable; falsy `0`/`false`/`no`/`off` → disable; invalid → default `True`). Param value, when explicitly passed, overrides env var.
+- CRITICAL: every task MUST include new/updated tests
+- CRITICAL: all tests must pass before starting next task
+
+## Implementation Steps
+
+### Task 1: Add `generate_spec` flag and disable path in core
+
+**Files:**
+- Modify: `aiohttp_apigami/core.py`
+- Modify: `tests/test_register.py`
+
+- [ ] Add `_ENV_VAR = "APIGAMI_GENERATE_SPEC"` constant and helper `_resolve_generate_spec(generate_spec: bool | None) -> bool` — returns `generate_spec` if not None, else parses env var (truthy/falsy strings), defaults to `True` when unset or invalid
+- [ ] Add `generate_spec: bool | None = None` kwarg to `AiohttpApiSpec.__init__`; add `_generate_spec` to `__slots__` and store resolved value
+- [ ] In `register()`: always set `app[APISPEC_VALIDATED_DATA_NAME]`, `app[APISPEC_PARSER]`, and `parser.error_callback` (so `validation_middleware` works); when `self._generate_spec is False`, skip `_register` / `_register_on_startup`, skip `_setup_spec_endpoint`, skip swagger UI setup; set `self._registered = True` and return
+- [ ] Add `generate_spec: bool | None = None` kwarg to `setup_aiohttp_apispec` and forward to `AiohttpApiSpec`
+- [ ] Update docstring on `setup_aiohttp_apispec` to document `generate_spec` semantics and `APIGAMI_GENERATE_SPEC` env var fallback
+- [ ] Write tests in `tests/test_register.py`:
+  - `generate_spec=False` skips swagger spec route and `SWAGGER_DICT` population
+  - `generate_spec=False` still configures `APISPEC_PARSER` + `APISPEC_VALIDATED_DATA_NAME` so middleware works
+  - `generate_spec=False` + `swagger_path` does not register Swagger UI routes
+  - Default (`generate_spec=None`, env unset) behaves identically to current behavior
+- [ ] Run project test suite — must pass before task 2
+
+### Task 2: Env var fallback support
+
+**Files:**
+- Modify: `tests/test_register.py`
+
+- [ ] Confirm `_resolve_generate_spec` reads env var only when param is `None`; explicit `generate_spec=True` or `generate_spec=False` always wins
+- [ ] Add tests using `monkeypatch.setenv`:
+  - `APIGAMI_GENERATE_SPEC=0` disables when param omitted
+  - `APIGAMI_GENERATE_SPEC=false` disables (case-insensitive)
+  - `APIGAMI_GENERATE_SPEC=1` enables (same as default)
+  - Explicit `generate_spec=True` overrides `APIGAMI_GENERATE_SPEC=0`
+  - Invalid env value (e.g. `maybe`) falls back to default `True`
+- [ ] Run test suite — must pass before task 3
+
+### Task 3: Documentation
+
+**Files:**
+- Modify: `README.md`
+
+- [ ] Add short section near "Setup Function" / quickstart describing `generate_spec` parameter and `APIGAMI_GENERATE_SPEC` env var, with testing example replacing the `patch("AiohttpApiSpec._register")` workaround from the issue
+- [ ] Run test suite — must pass before task 4
+
+### Task 4: Verify acceptance criteria
+
+- [ ] Run full test suite (`make test` or `pytest`)
+- [ ] Run linter (`make lint` or configured pre-commit)
+- [ ] Verify coverage on new branches in `core.py` exercised (target 80%+ overall, 100% on new code paths)
+
+### Task 5: Finalize
+
+- [ ] Update `CLAUDE.md` if internal patterns changed
+- [ ] Move this plan to `docs/plans/completed/`

--- a/docs/plans/completed/2026-05-12-disable-openapi-spec-generation.md
+++ b/docs/plans/completed/2026-05-12-disable-openapi-spec-generation.md
@@ -78,5 +78,5 @@ Resolves anna-money/aiohttp-apigami#110.
 
 ### Task 5: Finalize
 
-- [ ] Update `CLAUDE.md` if internal patterns changed
-- [ ] Move this plan to `docs/plans/completed/`
+- [x] Update `CLAUDE.md` if internal patterns changed (skipped — no `CLAUDE.md` in repo)
+- [x] Move this plan to `docs/plans/completed/`

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,11 +1,14 @@
 """Pytest configuration file."""
 # ruff: noqa: F403
 
+from collections.abc import Iterator
+
 import pytest
 from aiohttp import web
 from aiohttp.test_utils import TestClient
 from aiohttp.typedefs import Handler, Middleware
 from pytest_aiohttp.plugin import AiohttpClient
+from webargs.aiohttpparser import parser as _webargs_parser
 
 from aiohttp_apigami import setup_aiohttp_apispec, validation_middleware
 from aiohttp_apigami.typedefs import ErrorHandler
@@ -13,6 +16,18 @@ from aiohttp_apigami.typedefs import ErrorHandler
 # Import all fixtures - fixture modules import our handler classes
 from tests.fixtures import *
 from tests.fixtures.handlers import BasicHandlers, EchoHandlers
+
+
+@pytest.fixture(autouse=True)
+def _isolate_apigami_state(monkeypatch: pytest.MonkeyPatch) -> Iterator[None]:
+    # webargs parser is a module-level singleton; AiohttpApiSpec.register mutates
+    # its error_callback. Snapshot/restore prevents cross-test leakage.
+    monkeypatch.delenv("APIGAMI_GENERATE_SPEC", raising=False)
+    original_callback = _webargs_parser.error_callback
+    try:
+        yield
+    finally:
+        _webargs_parser.error_callback = original_callback
 
 
 @pytest.fixture(params=[True, False])

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -620,3 +620,17 @@ async def test_invalid_env_value_falls_back_to_default_true(monkeypatch: pytest.
     route_names = {route.name for route in app.router.routes() if route.name is not None}
     assert NAME_SWAGGER_SPEC in route_names
     assert SWAGGER_DICT in app
+
+
+@pytest.mark.parametrize("bad_value", ["0", "false", "off", "1", "true", 0, 1, "", "yes"])
+def test_non_bool_generate_spec_raises_type_error(bad_value: object) -> None:
+    """Non-bool explicit generate_spec values are rejected to avoid truthy-string footguns."""
+    app = web.Application()
+    with pytest.raises(TypeError, match="generate_spec must be bool or None"):
+        setup_aiohttp_apispec(
+            app=app,
+            title="Test API",
+            version="1.0.0",
+            in_place=True,
+            generate_spec=bad_value,  # type: ignore[arg-type]
+        )

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -496,10 +496,9 @@ async def test_generate_spec_false_with_swagger_path_no_ui() -> None:
 
 
 @pytest.mark.asyncio
-async def test_generate_spec_default_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+async def test_generate_spec_default_unchanged() -> None:
     """Default (generate_spec=None, env unset) behaves identically to old behavior."""
-    monkeypatch.delenv("APIGAMI_GENERATE_SPEC", raising=False)
-
+    # Env var cleanup handled by autouse fixture in conftest.py
     app = web.Application()
 
     @docs(tags=["x"], summary="x")

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -515,3 +515,109 @@ async def test_generate_spec_default_unchanged(monkeypatch: pytest.MonkeyPatch) 
     assert NAME_SWAGGER_SPEC in route_names
     assert SWAGGER_DICT in app
     assert "/x" in app[SWAGGER_DICT]["paths"]
+
+
+@pytest.mark.parametrize("env_value", ["0", "false", "FALSE", "False", "no", "off", " 0 "])
+@pytest.mark.asyncio
+async def test_env_var_disables_when_param_omitted(monkeypatch: pytest.MonkeyPatch, env_value: str) -> None:
+    """APIGAMI_GENERATE_SPEC=falsy disables spec generation when param omitted."""
+    monkeypatch.setenv("APIGAMI_GENERATE_SPEC", env_value)
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True)
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC not in route_names
+    assert SWAGGER_DICT not in app
+    # Parser still configured
+    assert APISPEC_PARSER in app
+
+
+@pytest.mark.parametrize("env_value", ["1", "true", "TRUE", "True", "yes", "on", " 1 "])
+@pytest.mark.asyncio
+async def test_env_var_enables_when_param_omitted(monkeypatch: pytest.MonkeyPatch, env_value: str) -> None:
+    """APIGAMI_GENERATE_SPEC=truthy enables spec generation (same as default)."""
+    monkeypatch.setenv("APIGAMI_GENERATE_SPEC", env_value)
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True)
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC in route_names
+    assert SWAGGER_DICT in app
+    assert "/x" in app[SWAGGER_DICT]["paths"]
+
+
+@pytest.mark.asyncio
+async def test_explicit_true_overrides_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit generate_spec=True overrides APIGAMI_GENERATE_SPEC=0."""
+    monkeypatch.setenv("APIGAMI_GENERATE_SPEC", "0")
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True, generate_spec=True)
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC in route_names
+    assert SWAGGER_DICT in app
+
+
+@pytest.mark.asyncio
+async def test_explicit_false_overrides_env_var(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Explicit generate_spec=False overrides APIGAMI_GENERATE_SPEC=1."""
+    monkeypatch.setenv("APIGAMI_GENERATE_SPEC", "1")
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True, generate_spec=False)
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC not in route_names
+    assert SWAGGER_DICT not in app
+
+
+@pytest.mark.parametrize("env_value", ["maybe", "", "2", "yesno", "random"])
+@pytest.mark.asyncio
+async def test_invalid_env_value_falls_back_to_default_true(monkeypatch: pytest.MonkeyPatch, env_value: str) -> None:
+    """Invalid APIGAMI_GENERATE_SPEC value falls back to default True."""
+    monkeypatch.setenv("APIGAMI_GENERATE_SPEC", env_value)
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True)
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC in route_names
+    assert SWAGGER_DICT in app

--- a/tests/test_register.py
+++ b/tests/test_register.py
@@ -2,7 +2,7 @@ import pytest
 from aiohttp import web
 
 from aiohttp_apigami import AiohttpApiSpec, docs, request_schema, setup_aiohttp_apispec
-from aiohttp_apigami.constants import APISPEC_PARSER, APISPEC_VALIDATED_DATA_NAME
+from aiohttp_apigami.constants import APISPEC_PARSER, APISPEC_VALIDATED_DATA_NAME, SWAGGER_DICT
 from aiohttp_apigami.core import OpenApiVersion
 from aiohttp_apigami.swagger_ui import NAME_SWAGGER_SPEC
 from tests.fixtures.schemas import RequestSchema
@@ -418,3 +418,100 @@ async def test_setup_aiohttp_apispec_with_subapps() -> None:
     # If a new route needs to be added after setup:
     # 1. Either use in_place=False to register routes on startup
     # 2. Or manually re-register all routes by calling setup again
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_false_skips_spec_route_and_dict() -> None:
+    """generate_spec=False must skip swagger.json route and SWAGGER_DICT build."""
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    initial_route_count = len(app.router.routes())
+    initial_startup_count = len(app.on_startup)
+
+    setup_aiohttp_apispec(
+        app=app,
+        title="Test API",
+        version="1.0.0",
+        in_place=True,
+        generate_spec=False,
+    )
+
+    # Swagger spec route not added
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC not in route_names
+    assert len(app.router.routes()) == initial_route_count
+
+    # SWAGGER_DICT not populated (even with in_place=True)
+    assert SWAGGER_DICT not in app
+
+    # No on_startup handler added either
+    assert len(app.on_startup) == initial_startup_count
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_false_still_registers_parser() -> None:
+    """generate_spec=False must still configure parser + request data name."""
+    app = web.Application()
+
+    def cb(*args: object, **kwargs: object) -> None:
+        pass
+
+    setup_aiohttp_apispec(
+        app=app,
+        title="Test API",
+        version="1.0.0",
+        request_data_name="payload",
+        error_callback=cb,
+        generate_spec=False,
+    )
+
+    assert app[APISPEC_VALIDATED_DATA_NAME] == "payload"
+    assert APISPEC_PARSER in app
+    assert app[APISPEC_PARSER].error_callback is cb
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_false_with_swagger_path_no_ui() -> None:
+    """generate_spec=False + swagger_path must NOT register Swagger UI routes."""
+    app = web.Application()
+
+    setup_aiohttp_apispec(
+        app=app,
+        title="Test API",
+        version="1.0.0",
+        swagger_path="/docs",
+        generate_spec=False,
+    )
+
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert "swagger.docs" not in route_names
+    assert "swagger.static" not in route_names
+    assert NAME_SWAGGER_SPEC not in route_names
+
+
+@pytest.mark.asyncio
+async def test_generate_spec_default_unchanged(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Default (generate_spec=None, env unset) behaves identically to old behavior."""
+    monkeypatch.delenv("APIGAMI_GENERATE_SPEC", raising=False)
+
+    app = web.Application()
+
+    @docs(tags=["x"], summary="x")
+    async def handler(request: web.Request) -> web.Response:
+        return web.Response(text="ok")
+
+    app.router.add_get("/x", handler)
+
+    setup_aiohttp_apispec(app=app, title="Test API", version="1.0.0", in_place=True)
+
+    # Swagger route registered, SWAGGER_DICT populated
+    route_names = {route.name for route in app.router.routes() if route.name is not None}
+    assert NAME_SWAGGER_SPEC in route_names
+    assert SWAGGER_DICT in app
+    assert "/x" in app[SWAGGER_DICT]["paths"]


### PR DESCRIPTION
## Summary
Adds a `generate_spec` flag to `setup_aiohttp_apispec` / `AiohttpApiSpec` to skip OpenAPI spec building, swagger endpoint, and Swagger UI mounting while keeping `validation_middleware` working. Useful for tests and production deployments that don't need docs — replaces the `patch("AiohttpApiSpec._register")` workaround. Resolves anna-money/aiohttp-apigami#110.

## Changes
- New `generate_spec` kwarg on `setup_aiohttp_apispec` and `AiohttpApiSpec`. Defaults to `None`, in which case the `APIGAMI_GENERATE_SPEC` env var is consulted (`1`/`true`/`yes`/`on` vs `0`/`false`/`no`/`off`, case-insensitive). Unset or unrecognized env values log a warning and fall back to enabled. Passing a non-bool raises `TypeError` to avoid the usual truthy-string footgun.
- When disabled, route scanning, spec build, swagger endpoint, and Swagger UI mount are all skipped. The parser, validated-data key, and `error_callback` are still wired up so `validation_middleware` keeps working.
- Tests cover the disable path, env var fallback (truthy/falsy/invalid/whitespace), explicit param overriding env, and the `TypeError` case. An autouse fixture in `conftest.py` clears the env var and restores the module-level webargs parser's `error_callback` between tests, since it's a singleton.
- README gets a "Disabling Spec Generation" section with parameter, env var, and a testing fixture example.