### PR TITLE
Fix: Decimal Range bounds break swagger.json with 500

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- `fields.Decimal` combined with `validate.Range` no longer breaks the spec endpoint. apispec serializes the validator `min`/`max` bounds back through the field, producing `Decimal` values that `json.dumps` cannot serialize, so `swagger.json` returned a 500. `swagger_dict()` now converts `Decimal` values to `int`/`float`. Resolves [#115](https://github.com/anna-money/aiohttp-apigami/issues/115).
+
 ## [0.7.0] - 2026-05-12
 
 ### Added

--- a/aiohttp_apigami/core.py
+++ b/aiohttp_apigami/core.py
@@ -1,7 +1,7 @@
 import enum
 import logging.config
 import os
-from typing import Any
+from typing import Any, cast
 
 from aiohttp import web
 from apispec import APISpec
@@ -13,6 +13,7 @@ from .plugin import ApigamiPlugin
 from .route_processor import RouteProcessor
 from .swagger_ui import NAME_SWAGGER_SPEC, LayoutOption, SwaggerUIManager
 from .typedefs import SchemaNameResolver, SchemaType
+from .utils import make_json_serializable
 
 logger = logging.getLogger(__name__)
 
@@ -146,7 +147,7 @@ class AiohttpApiSpec:
 
     def swagger_dict(self) -> dict[str, Any]:
         """Returns swagger spec representation in JSON format"""
-        return self._spec.to_dict()
+        return cast("dict[str, Any]", make_json_serializable(self._spec.to_dict()))
 
     def register(self, app: web.Application, in_place: bool = False) -> None:
         """Creates spec based on registered app routes and registers needed view"""

--- a/aiohttp_apigami/utils.py
+++ b/aiohttp_apigami/utils.py
@@ -1,4 +1,5 @@
 from dataclasses import is_dataclass
+from decimal import Decimal
 from inspect import isclass
 from string import Formatter
 from typing import Any, TypeVar, get_origin
@@ -81,3 +82,23 @@ def resolve_schema_instance(schema: SchemaType | type[TDataclass]) -> m.Schema:
         return mr.schema(schema)
 
     raise ValueError(f"Invalid schema type: {schema}")
+
+
+def make_json_serializable(value: Any) -> Any:
+    """Recursively convert spec values into JSON-serializable types.
+
+    apispec serializes ``validate.Range`` bounds back through the field they are
+    attached to (see ``FieldConverterMixin.field2range``). For a ``fields.Decimal``
+    field this yields ``Decimal`` ``minimum``/``maximum`` values, which the stdlib
+    ``json`` encoder used by ``web.json_response`` cannot serialize.
+
+    Decimals are converted to ``int`` when integral and ``float`` otherwise.
+    See https://github.com/anna-money/aiohttp-apigami/issues/115.
+    """
+    if isinstance(value, dict):
+        return {k: make_json_serializable(v) for k, v in value.items()}
+    if isinstance(value, list):
+        return [make_json_serializable(v) for v in value]
+    if isinstance(value, Decimal):
+        return int(value) if value == value.to_integral_value() else float(value)
+    return value

--- a/tests/test_decimal_range.py
+++ b/tests/test_decimal_range.py
@@ -1,0 +1,60 @@
+"""Regression tests for https://github.com/anna-money/aiohttp-apigami/issues/115.
+
+``fields.Decimal`` combined with ``validate.Range`` made apispec serialize the
+``min``/``max`` bounds back through the field, producing ``Decimal`` values in
+the spec dict. ``json.dumps`` cannot serialize ``Decimal``, so the
+``swagger.json`` endpoint returned a 500.
+"""
+
+import json
+from decimal import Decimal
+from typing import Any
+
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+from marshmallow import Schema, fields, validate
+from pytest_aiohttp.plugin import AiohttpClient
+
+from aiohttp_apigami import request_schema, setup_aiohttp_apispec
+from aiohttp_apigami.constants import SWAGGER_DICT
+
+
+class DecimalSchema(Schema):
+    amount = fields.Decimal(
+        required=True,
+        validate=validate.Range(min=0, max=100, min_inclusive=False),
+    )
+
+
+@request_schema(DecimalSchema)
+async def decimal_handler(request: web.Request) -> web.Response:
+    return web.json_response({"msg": "done"})
+
+
+def _build_app() -> web.Application:
+    app = web.Application()
+    app.router.add_post("/decimal", decimal_handler)
+    setup_aiohttp_apispec(app=app, url="/api/docs/api-docs", in_place=True)
+    return app
+
+
+def test_swagger_dict_is_json_serializable() -> None:
+    app = _build_app()
+    # Should not raise "Object of type Decimal is not JSON serializable".
+    json.dumps(app[SWAGGER_DICT])
+
+    amount = app[SWAGGER_DICT]["definitions"]["Decimal"]["properties"]["amount"]
+    assert amount["minimum"] == 0
+    assert amount["maximum"] == 100
+    assert not isinstance(amount["minimum"], Decimal)
+    assert not isinstance(amount["maximum"], Decimal)
+
+
+async def test_swagger_json_endpoint_returns_200(aiohttp_client: AiohttpClient) -> None:
+    client: TestClient[web.Request, web.Application] = await aiohttp_client(_build_app())
+    resp = await client.get("/api/docs/api-docs")
+    assert resp.status == 200
+    docs: dict[str, Any] = await resp.json()
+    amount = docs["definitions"]["Decimal"]["properties"]["amount"]
+    assert amount["minimum"] == 0
+    assert amount["maximum"] == 100


### PR DESCRIPTION
## Summary

`fields.Decimal` combined with `validate.Range` caused `GET /api/doc/swagger.json` to return 500.

apispec's `FieldConverterMixin.field2range` serializes the validator `min`/`max` bounds back through the field they are attached to. For a `Decimal` field this produces `Decimal` `minimum`/`maximum` values in the spec dict. The stdlib `json` encoder used by `web.json_response` cannot serialize `Decimal`, raising `TypeError: Object of type Decimal is not JSON serializable`.

## Changes

- `aiohttp_apigami/utils.py` — added `make_json_serializable()`, which recursively walks the spec and converts `Decimal` values to `int` (when integral) or `float`.
- `aiohttp_apigami/core.py` — `swagger_dict()` now passes the spec through `make_json_serializable()`. Fixes the spec endpoint, Swagger UI, and any direct `swagger_dict()` use.
- `tests/test_decimal_range.py` — regression tests covering dict serializability and the endpoint returning 200 with correct `minimum`/`maximum`.
- `CHANGELOG.md` — Unreleased / Fixed entry.

Resolves #115