### PR TITLE
Add aiohttp-apispec compatibility shims and expand migration guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `use_kwargs` and `marshal_with` aliases (for `request_schema` and `response_schema`), restoring the `aiohttp-apispec` public API.
 - Compatibility shim for the deprecated `aiohttp-apispec` `locations=[...]` argument on `request_schema`: a single-element list is accepted with a `DeprecationWarning`; multiple locations raise `ValueError`.
+- Built-in `flat_error_handler` error callback that restores the flat `aiohttp-apispec` 2.x validation error format (strips the webargs 8 location level from `error.messages`): `setup_aiohttp_apispec(app, error_callback=flat_error_handler)`.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- `use_kwargs` and `marshal_with` aliases (for `request_schema` and `response_schema`), restoring the `aiohttp-apispec` public API.
+- Compatibility shim for the deprecated `aiohttp-apispec` `locations=[...]` argument on `request_schema`: a single-element list is accepted with a `DeprecationWarning`; multiple locations raise `ValueError`.
+
+### Changed
+
+- **Breaking:** `request_schema` raises `TypeError` on unrecognized keyword arguments instead of silently ignoring them.
+- **Breaking:** when no schema targets the default key, `request["data"]` now defaults to `{}` instead of `[]`, matching `aiohttp-apispec` 2.x.
+- Expanded the "Migration from aiohttp-apispec" README section to cover all known behavioral differences (default parse location, unknown-field handling, schema merging, nested error messages, removed app keys).
+
 ## [0.7.1] - 2026-06-05
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -475,54 +475,15 @@ This affects:
 - Custom `error_callback` implementations that read `error.messages`
 - API clients that parse the default 422 response body
 
-If your API consumers depend on the old flat format, flatten the messages in a custom `error_callback`:
+If your API consumers depend on the old flat format, use the built-in `flat_error_handler`, which strips the location level and responds with 422 exactly like `aiohttp-apispec` 2.x:
 
 ```python
-import json
-import logging
-from typing import Any, NoReturn
-
-from aiohttp import web
-from marshmallow import Schema, ValidationError
-
-logger = logging.getLogger(__name__)
-
-
-def flat_error_handler(
-    error: ValidationError,
-    req: web.Request,
-    schema: Schema,
-    *args: Any,
-    error_status_code: int,
-    error_headers: dict[str, str],
-) -> NoReturn:
-    """Restore the flat aiohttp-apispec error format."""
-    messages = error.messages
-    if isinstance(messages, dict):
-        if len(messages) > 1:
-            logger.error(
-                "Validation errors in multiple locations %s; "
-                "flattening may overwrite same-named fields",
-                list(messages),
-            )
-        # Strip the location level (e.g. {"json": {...}} -> {...})
-        flat = {
-            field: errors
-            for value in messages.values()
-            if isinstance(value, dict)
-            for field, errors in value.items()
-        }
-        messages = flat or messages
-
-    raise web.HTTPUnprocessableEntity(
-        body=json.dumps(messages),
-        headers=error_headers,
-        content_type="application/json",
-    )
-
+from aiohttp_apigami import flat_error_handler, setup_aiohttp_apispec
 
 setup_aiohttp_apispec(app, error_callback=flat_error_handler)
 ```
+
+When validation fails in several locations at once, flattening may overwrite same-named fields — the handler logs an error in that case.
 
 ### Loud breaking changes (fail fast)
 

--- a/README.md
+++ b/README.md
@@ -408,9 +408,45 @@ app.middlewares.extend([intercept_error, validation_middleware])
 
 ## ⚠️ Migration from aiohttp-apispec
 
-**aiohttp-apigami** is a near drop-in replacement for `aiohttp-apispec`, with one breaking change to be aware of.
+**aiohttp-apigami** is a near drop-in replacement for `aiohttp-apispec` 2.x. The setup and decorator APIs are compatible (including the `use_kwargs` / `marshal_with` aliases), but the upgrade from webargs < 6 to webargs 8.x changes validation behavior in several ways. Review the items below before migrating — the first group is **silent**: code imports and runs, but requests are validated differently.
 
-### Validation error messages are nested by request location
+### Silent behavior changes
+
+#### 1. The default parse location is now `json` only
+
+With webargs < 6, `@request_schema(MySchema)` without an explicit location searched `querystring`, `form`, and `json` and used whichever had data. aiohttp-apigami parses **only `json`** by default.
+
+If a handler relied on the multi-location fallback (typically GET endpoints reading query parameters through a bare `@request_schema` / `@use_kwargs`), set the location explicitly:
+
+```python
+@request_schema(MySchema, location="querystring")
+```
+
+#### 2. Unknown request fields now cause 422 errors
+
+webargs < 6 looked up declared schema fields one by one, so extra query parameters or JSON keys were silently ignored. webargs 8 passes the whole payload to the schema, and aiohttp-apigami defers to the schema's `unknown` setting — marshmallow's default is `RAISE`. A request with an unexpected parameter (e.g. `?utm_source=...`) now fails with 422.
+
+To restore the old tolerance, set `unknown` on your schemas (or on a shared base schema):
+
+```python
+import marshmallow as ma
+
+
+class MySchema(ma.Schema):
+    class Meta:
+        unknown = ma.EXCLUDE
+```
+
+#### 3. Multiple schemas without `put_into` no longer merge
+
+`aiohttp-apispec` merged validated data from several `@request_schema` decorators into a single `request["data"]` dict. aiohttp-apigami stores only the **first** schema's data there (and logs a warning). Use `put_into` (or the location shortcuts such as `@querystring_schema`, which set it automatically) to keep each location's data separate:
+
+```python
+@request_schema(BodySchema)  # -> request["data"]
+@request_schema(QuerySchema, location="querystring", put_into="query")  # -> request["query"]
+```
+
+#### 4. Validation error messages are nested by request location
 
 `aiohttp-apispec` relied on webargs < 6, which passed flat field-level messages to the error handler. **aiohttp-apigami** uses webargs 8.x, which nests `ValidationError.messages` under the request location key (`json`, `querystring`, `form`, `headers`, etc.).
 
@@ -487,6 +523,39 @@ def flat_error_handler(
 
 setup_aiohttp_apispec(app, error_callback=flat_error_handler)
 ```
+
+### Loud breaking changes (fail fast)
+
+These surface immediately as exceptions, so they are easy to catch in tests.
+
+#### `locations=[...]` is deprecated — use `location="..."`
+
+The plural `locations` list argument from `aiohttp-apispec` is accepted as a shim: a single-element list works and emits a `DeprecationWarning`. A multi-element list raises `ValueError`, because webargs 8 cannot parse several locations with one schema — split it into one decorator per location:
+
+```python
+# Before (aiohttp-apispec)
+@request_schema(MySchema, locations=["querystring", "form"])
+
+# After (aiohttp-apigami)
+@request_schema(QuerySchema, location="querystring", put_into="query")
+@request_schema(FormSchema, location="form", put_into="form")
+```
+
+#### Two schemas for the same location raise `RuntimeError`
+
+`aiohttp-apispec` allowed stacking several schemas on one location and merged the results. aiohttp-apigami raises `RuntimeError` at decoration time — combine the fields into a single schema instead.
+
+#### Unknown decorator keyword arguments raise `TypeError`
+
+`@request_schema(MySchema, locatoins=[...])` (note the typo) was silently ignored by `aiohttp-apispec`'s `**kwargs`. aiohttp-apigami raises `TypeError` for any unrecognized keyword argument.
+
+#### Internal app keys were removed
+
+`app["_apispec_parser"]` and `app["_apispec_request_data_name"]` no longer exist (replaced by typed, private `AppKey`s). `app["swagger_dict"]` is still available.
+
+### Other differences
+
+- When no schema targets the default key, `request["data"]` defaults to `{}`, matching `aiohttp-apispec` 2.x (aiohttp-apigami < 0.8 used `[]`).
 
 ## 📝 Swagger UI Integration
 

--- a/aiohttp_apigami/__init__.py
+++ b/aiohttp_apigami/__init__.py
@@ -1,6 +1,7 @@
 # mypy: disable-error-code="attr-defined"
 from importlib import metadata
 
+from .compat import flat_error_handler
 from .core import AiohttpApiSpec, OpenApiVersion, setup_aiohttp_apispec
 from .decorators import (
     cookies_schema,
@@ -23,6 +24,7 @@ __all__ = [
     "__version__",
     "cookies_schema",
     "docs",
+    "flat_error_handler",
     "form_schema",
     "headers_schema",
     "json_schema",

--- a/aiohttp_apigami/__init__.py
+++ b/aiohttp_apigami/__init__.py
@@ -8,10 +8,12 @@ from .decorators import (
     form_schema,
     headers_schema,
     json_schema,
+    marshal_with,
     match_info_schema,
     querystring_schema,
     request_schema,
     response_schema,
+    use_kwargs,
 )
 from .middlewares import validation_middleware
 
@@ -24,11 +26,13 @@ __all__ = [
     "form_schema",
     "headers_schema",
     "json_schema",
+    "marshal_with",
     "match_info_schema",
     "querystring_schema",
     "request_schema",
     "response_schema",
     "setup_aiohttp_apispec",
+    "use_kwargs",
     "validation_middleware",
 ]
 

--- a/aiohttp_apigami/compat.py
+++ b/aiohttp_apigami/compat.py
@@ -1,0 +1,66 @@
+"""Helpers for code migrating from aiohttp-apispec."""
+
+import json
+import logging
+from typing import Any, NoReturn
+
+import marshmallow as m
+from aiohttp import web
+
+logger = logging.getLogger(__name__)
+
+
+def flat_error_handler(
+    error: m.ValidationError,
+    req: web.Request,
+    schema: m.Schema,
+    *args: Any,
+    error_status_code: int | None = None,
+    error_headers: dict[str, str] | None = None,
+) -> NoReturn:
+    """
+    Error callback restoring the flat aiohttp-apispec 2.x error format.
+
+    webargs 8 nests ``ValidationError.messages`` under the request location,
+    e.g. ``{"json": {"field": ["Not a valid integer."]}}``. This handler
+    strips the location level, so API clients keep receiving the flat
+    ``{"field": ["Not a valid integer."]}`` body with a 422 response,
+    exactly like aiohttp-apispec 2.x.
+
+    If validation fails in several locations at once, flattening may
+    overwrite same-named fields; an error is logged when that risk exists.
+
+    Usage:
+
+    .. code-block:: python
+
+        from aiohttp_apigami import (
+            flat_error_handler,
+            setup_aiohttp_apispec,
+        )
+
+        setup_aiohttp_apispec(
+            app, error_callback=flat_error_handler
+        )
+    """
+    messages = error.messages
+    if isinstance(messages, dict):
+        if len(messages) > 1:
+            logger.error(
+                "Validation errors in multiple locations %s; flattening may overwrite same-named fields",
+                sorted(messages),
+            )
+        # Strip the location level (e.g. {"json": {...}} -> {...})
+        flat = {
+            field: field_errors
+            for location_errors in messages.values()
+            if isinstance(location_errors, dict)
+            for field, field_errors in location_errors.items()
+        }
+        messages = flat or messages
+
+    raise web.HTTPUnprocessableEntity(
+        text=json.dumps(messages),
+        headers=error_headers,
+        content_type="application/json",
+    )

--- a/aiohttp_apigami/decorators/__init__.py
+++ b/aiohttp_apigami/decorators/__init__.py
@@ -8,5 +8,6 @@ from .request import (
     match_info_schema,
     querystring_schema,
     request_schema,
+    use_kwargs,
 )
-from .response import response_schema
+from .response import marshal_with, response_schema

--- a/aiohttp_apigami/decorators/request.py
+++ b/aiohttp_apigami/decorators/request.py
@@ -129,8 +129,12 @@ def request_schema(
             DeprecationWarning,
             stacklevel=2,
         )
+        if isinstance(locations, str) or not isinstance(locations, (list, tuple)):
+            raise TypeError("`locations` must be a list/tuple of location strings")
         if location != "json":
             raise ValueError("Use either `location` or `locations`, not both")
+        if len(locations) == 0:
+            raise ValueError("`locations` must contain exactly one location")
         if len(locations) != 1:
             raise ValueError(
                 f"Multiple locations are not supported: {locations}. "

--- a/aiohttp_apigami/decorators/request.py
+++ b/aiohttp_apigami/decorators/request.py
@@ -1,4 +1,5 @@
 import copy
+import warnings
 from collections.abc import Callable
 from functools import partial
 from typing import Any, Literal, TypeVar
@@ -115,7 +116,27 @@ def request_schema(
     add_to_refs : bool, default=False
         Works only if example is not None. If True, adds example
         for ref schema. Otherwise, adds example to endpoint.
+
+    locations : list, optional
+        Deprecated aiohttp-apispec argument. A single-element list is
+        accepted as an alias for ``location``; webargs 8 cannot parse
+        multiple locations with one schema.
     """
+    locations = kwargs.pop("locations", None)
+    if locations is not None:
+        warnings.warn(
+            "The `locations` argument is deprecated, use `location` instead",
+            DeprecationWarning,
+            stacklevel=2,
+        )
+        if location != "json":
+            raise ValueError("Use either `location` or `locations`, not both")
+        if len(locations) != 1:
+            raise ValueError(
+                f"Multiple locations are not supported: {locations}. "
+                f"Use a separate @request_schema(..., location=...) decorator per location"
+            )
+        location = locations[0]
 
     if location not in VALID_SCHEMA_LOCATIONS:
         raise ValueError(f"Invalid location argument: {location}")
@@ -123,6 +144,8 @@ def request_schema(
     schema_instance = resolve_schema_instance(schema)
 
     options = {"required": kwargs.pop("required", False)}
+    if kwargs:
+        raise TypeError(f"request_schema() got unexpected keyword arguments: {sorted(kwargs)}")
 
     def wrapper(func: T) -> T:
         func_apispec = get_or_set_apispec(func)
@@ -156,6 +179,9 @@ def request_schema(
 
     return wrapper
 
+
+# Alias kept for code migrating from aiohttp-apispec
+use_kwargs = request_schema
 
 # Decorators for specific request data validations (shortenings)
 match_info_schema = partial(request_schema, location="match_info", put_into="match_info")

--- a/aiohttp_apigami/decorators/request.py
+++ b/aiohttp_apigami/decorators/request.py
@@ -36,6 +36,9 @@ VALID_SCHEMA_LOCATIONS = (
 T = TypeVar("T", bound=HandlerType)
 TDataclass = TypeVar("TDataclass", bound=IDataclass)
 
+# Default request location when neither `location` nor `locations` is provided
+_DEFAULT_LOCATION: ValidLocations = "json"
+
 # Sentinel to tell an explicit `location` apart from the default
 # when the deprecated `locations` kwarg is also passed
 _UNSET: Any = object()
@@ -45,7 +48,7 @@ def _resolve_location(location: ValidLocations, kwargs: dict[str, Any]) -> Valid
     """Resolve `location`, honoring the deprecated aiohttp-apispec `locations` kwarg."""
     locations = kwargs.pop("locations", None)
     if locations is None:
-        return "json" if location is _UNSET else location
+        return _DEFAULT_LOCATION if location is _UNSET else location
 
     warnings.warn(
         "The `locations` argument is deprecated, use `location` instead",

--- a/aiohttp_apigami/decorators/request.py
+++ b/aiohttp_apigami/decorators/request.py
@@ -36,10 +36,38 @@ VALID_SCHEMA_LOCATIONS = (
 T = TypeVar("T", bound=HandlerType)
 TDataclass = TypeVar("TDataclass", bound=IDataclass)
 
+# Sentinel to tell an explicit `location` apart from the default
+# when the deprecated `locations` kwarg is also passed
+_UNSET: Any = object()
+
+
+def _resolve_location(location: ValidLocations, kwargs: dict[str, Any]) -> ValidLocations:
+    """Resolve `location`, honoring the deprecated aiohttp-apispec `locations` kwarg."""
+    locations = kwargs.pop("locations", None)
+    if locations is None:
+        return "json" if location is _UNSET else location
+
+    warnings.warn(
+        "The `locations` argument is deprecated, use `location` instead",
+        DeprecationWarning,
+        stacklevel=3,
+    )
+    if location is not _UNSET:
+        raise ValueError("Use either `location` or `locations`, not both")
+    if not isinstance(locations, (list, tuple)):
+        raise TypeError(f"`locations` must be a list, got {type(locations).__name__}")
+    if len(locations) != 1:
+        raise ValueError(
+            f"`locations` must contain exactly one location, got {list(locations)}. "
+            f"Use a separate @request_schema(..., location=...) decorator per location"
+        )
+    result: ValidLocations = locations[0]
+    return result
+
 
 def request_schema(
     schema: SchemaType | type[TDataclass],
-    location: ValidLocations = "json",
+    location: ValidLocations = _UNSET,
     put_into: str | None = None,
     example: dict[str, Any] | None = None,
     add_to_refs: bool = False,
@@ -122,25 +150,7 @@ def request_schema(
         accepted as an alias for ``location``; webargs 8 cannot parse
         multiple locations with one schema.
     """
-    locations = kwargs.pop("locations", None)
-    if locations is not None:
-        warnings.warn(
-            "The `locations` argument is deprecated, use `location` instead",
-            DeprecationWarning,
-            stacklevel=2,
-        )
-        if isinstance(locations, str) or not isinstance(locations, (list, tuple)):
-            raise TypeError("`locations` must be a list/tuple of location strings")
-        if location != "json":
-            raise ValueError("Use either `location` or `locations`, not both")
-        if len(locations) == 0:
-            raise ValueError("`locations` must contain exactly one location")
-        if len(locations) != 1:
-            raise ValueError(
-                f"Multiple locations are not supported: {locations}. "
-                f"Use a separate @request_schema(..., location=...) decorator per location"
-            )
-        location = locations[0]
+    location = _resolve_location(location, kwargs)
 
     if location not in VALID_SCHEMA_LOCATIONS:
         raise ValueError(f"Invalid location argument: {location}")

--- a/aiohttp_apigami/decorators/response.py
+++ b/aiohttp_apigami/decorators/response.py
@@ -87,3 +87,7 @@ def response_schema(
         return func
 
     return wrapper
+
+
+# Alias kept for code migrating from aiohttp-apispec
+marshal_with = response_schema

--- a/aiohttp_apigami/middlewares.py
+++ b/aiohttp_apigami/middlewares.py
@@ -77,8 +77,8 @@ async def validation_middleware(request: web.Request, handler: Handler) -> web.S
         else:
             logger.warning("Multiple schemas provided, but no put_into specified. Using the first one only.")
 
-    # For backward compatibility, if no validated data is provided, use the list
-    result = [] if result is _missing else result
+    # aiohttp-apispec 2.x stored an empty dict when no schema targeted the default key
+    result = {} if result is _missing else result
 
     # Store validated data in request object
     request[request.app[APISPEC_VALIDATED_DATA_NAME]] = result

--- a/tests/decorators/test_apispec_compat.py
+++ b/tests/decorators/test_apispec_compat.py
@@ -1,0 +1,63 @@
+"""Backward compatibility shims for code migrating from aiohttp-apispec."""
+
+import pytest
+from aiohttp import web
+
+from aiohttp_apigami import marshal_with, request_schema, response_schema, use_kwargs
+from tests.fixtures.schemas import RequestSchema
+
+
+class TestAliases:
+    def test_use_kwargs_is_request_schema(self) -> None:
+        assert use_kwargs is request_schema
+
+    def test_marshal_with_is_response_schema(self) -> None:
+        assert marshal_with is response_schema
+
+
+class TestLocationsShim:
+    def test_single_location_list_is_accepted_with_deprecation_warning(self) -> None:
+        with pytest.warns(DeprecationWarning, match="`locations` argument is deprecated"):
+
+            @request_schema(RequestSchema, locations=["querystring"])
+            async def handler(request: web.Request) -> web.Response:
+                return web.json_response({})
+
+        assert handler.__schemas__[0].location == "querystring"  # type: ignore[attr-defined]
+        assert handler.__apispec__["schemas"][0]["location"] == "querystring"  # type: ignore[attr-defined]
+
+    def test_multiple_locations_raise_value_error(self) -> None:
+        with (
+            pytest.warns(DeprecationWarning),
+            pytest.raises(ValueError, match="Multiple locations are not supported"),
+        ):
+
+            @request_schema(RequestSchema, locations=["querystring", "form"])
+            async def handler(request: web.Request) -> web.Response:
+                return web.json_response({})
+
+    def test_location_and_locations_together_raise_value_error(self) -> None:
+        with (
+            pytest.warns(DeprecationWarning),
+            pytest.raises(ValueError, match="not both"),
+        ):
+
+            @request_schema(RequestSchema, location="form", locations=["querystring"])
+            async def handler(request: web.Request) -> web.Response:
+                return web.json_response({})
+
+
+class TestUnknownKwargs:
+    def test_unexpected_keyword_argument_raises_type_error(self) -> None:
+        with pytest.raises(TypeError, match="unexpected keyword arguments: \\['foo'\\]"):
+
+            @request_schema(RequestSchema, foo=1)
+            async def handler(request: web.Request) -> web.Response:
+                return web.json_response({})
+
+    def test_required_kwarg_still_accepted(self) -> None:
+        @request_schema(RequestSchema, required=True)
+        async def handler(request: web.Request) -> web.Response:
+            return web.json_response({})
+
+        assert handler.__apispec__["schemas"][0]["options"] == {"required": True}  # type: ignore[attr-defined]

--- a/tests/decorators/test_apispec_compat.py
+++ b/tests/decorators/test_apispec_compat.py
@@ -26,23 +26,35 @@ class TestLocationsShim:
         assert handler.__schemas__[0].location == "querystring"  # type: ignore[attr-defined]
         assert handler.__apispec__["schemas"][0]["location"] == "querystring"  # type: ignore[attr-defined]
 
-    def test_multiple_locations_raise_value_error(self) -> None:
+    @pytest.mark.parametrize("bad_locations", [["querystring", "form"], []])
+    def test_non_single_locations_raise_value_error(self, bad_locations: list[str]) -> None:
         with (
             pytest.warns(DeprecationWarning),
-            pytest.raises(ValueError, match="Multiple locations are not supported"),
+            pytest.raises(ValueError, match="must contain exactly one location"),
         ):
 
-            @request_schema(RequestSchema, locations=["querystring", "form"])
+            @request_schema(RequestSchema, locations=bad_locations)
             async def handler(request: web.Request) -> web.Response:
                 return web.json_response({})
 
-    def test_location_and_locations_together_raise_value_error(self) -> None:
+    @pytest.mark.parametrize("explicit_location", ["form", "json"])
+    def test_location_and_locations_together_raise_value_error(self, explicit_location: str) -> None:
         with (
             pytest.warns(DeprecationWarning),
             pytest.raises(ValueError, match="not both"),
         ):
 
-            @request_schema(RequestSchema, location="form", locations=["querystring"])
+            @request_schema(RequestSchema, location=explicit_location, locations=["querystring"])  # type: ignore[arg-type]
+            async def handler(request: web.Request) -> web.Response:
+                return web.json_response({})
+
+    def test_non_list_locations_raise_type_error(self) -> None:
+        with (
+            pytest.warns(DeprecationWarning),
+            pytest.raises(TypeError, match="`locations` must be a list, got str"),
+        ):
+
+            @request_schema(RequestSchema, locations="querystring")
             async def handler(request: web.Request) -> web.Response:
                 return web.json_response({})
 

--- a/tests/test_flat_error_handler.py
+++ b/tests/test_flat_error_handler.py
@@ -1,0 +1,55 @@
+"""Tests for the built-in aiohttp-apispec flat error format adapter."""
+
+import json
+from typing import Any
+
+import pytest
+from aiohttp import web
+from marshmallow import ValidationError
+from pytest_aiohttp.plugin import AiohttpClient
+
+from aiohttp_apigami import flat_error_handler, request_schema, setup_aiohttp_apispec, validation_middleware
+from tests.fixtures.schemas import RequestSchema
+
+
+class TestUnit:
+    def _call(self, messages: Any) -> web.HTTPUnprocessableEntity:
+        with pytest.raises(web.HTTPUnprocessableEntity) as exc_info:
+            flat_error_handler(
+                ValidationError(messages),
+                req=None,  # type: ignore[arg-type]
+                schema=None,  # type: ignore[arg-type]
+                error_status_code=422,
+                error_headers=None,
+            )
+        return exc_info.value
+
+    def test_strips_location_level(self) -> None:
+        exc = self._call({"json": {"id": ["Not a valid integer."]}})
+        assert json.loads(exc.text or "") == {"id": ["Not a valid integer."]}
+
+    def test_merges_multiple_locations_and_logs(self, caplog: pytest.LogCaptureFixture) -> None:
+        exc = self._call({"json": {"a": ["x"]}, "querystring": {"b": ["y"]}})
+        assert json.loads(exc.text or "") == {"a": ["x"], "b": ["y"]}
+        assert "flattening may overwrite same-named fields" in caplog.text
+
+    def test_non_nested_messages_kept_as_is(self) -> None:
+        exc = self._call(["plain error"])
+        assert json.loads(exc.text or "") == ["plain error"]
+
+
+async def test_response_body_is_flat(aiohttp_client: AiohttpClient) -> None:
+    @request_schema(RequestSchema)
+    async def handler(request: web.Request) -> web.Response:
+        return web.json_response({})
+
+    app = web.Application()
+    app.router.add_post("/test", handler)
+    setup_aiohttp_apispec(app, error_callback=flat_error_handler)
+    app.middlewares.append(validation_middleware)
+
+    client = await aiohttp_client(app)
+    res = await client.post("/test", json={"id": "not-an-int"})
+
+    assert res.status == 422
+    assert await res.json() == {"id": ["Not a valid integer."]}

--- a/tests/test_web_app.py
+++ b/tests/test_web_app.py
@@ -150,7 +150,7 @@ async def test_swagger_handler_200(aiohttp_app: Any) -> None:
 async def test_match_info(aiohttp_app: Any) -> None:
     res = await aiohttp_app.get("/v1/variable/hello")
     assert res.status == 200
-    assert await res.json() == []
+    assert await res.json() == {}
 
 
 async def test_validators(aiohttp_app: Any) -> None:


### PR DESCRIPTION
## Summary

A thorough backward-compatibility audit against **aiohttp-apispec 2.2.3** (the last stable release, webargs < 6) found 8 undocumented breaking changes on top of the already-documented nested `error.messages` — three of them **silent** (code imports and runs, but validation behaves differently). This PR restores compatibility where it is cheap and documents everything else.

## Changes

### Code (compat shims)

- **`use_kwargs` / `marshal_with` aliases** for `request_schema` / `response_schema` — previously `ImportError` on code migrating from aiohttp-apispec.
- **`locations=[...]` shim** on `request_schema`: previously the kwarg was silently swallowed by `**kwargs` and validation fell back to the `json` location. Now a single-element list works (with `DeprecationWarning`); a non-list raises `TypeError`; an empty or multi-element list raises `ValueError` (webargs 8 can't parse several locations with one schema); combining explicit `location=` (even `"json"`) with `locations=` raises `ValueError`.
- **`TypeError` on unrecognized `request_schema` kwargs** — closes the silent-swallowing hole for good (typos included).
- **Built-in `flat_error_handler`** — error callback restoring the flat aiohttp-apispec 2.x validation error format (strips the webargs 8 location level from `error.messages`, responds 422). Logs an error when flattening multiple locations could overwrite same-named fields. `setup_aiohttp_apispec(app, error_callback=flat_error_handler)`.
- **`request["data"]` default `[]` → `{}`** when no schema targets the default key, matching aiohttp-apispec 2.x (the `[]` was copied from the 3.0.0b2 beta).

### Documented only (intentional webargs 8 semantics, not patched)

- Default parse location is now `json` only (webargs 5 searched `querystring` → `form` → `json`).
- Unknown request fields now raise 422 (marshmallow `RAISE` default); workaround: `Meta.unknown = ma.EXCLUDE`.
- Multiple schemas without `put_into`: merge → first-wins.
- Two schemas on one location: `RuntimeError` at decoration time.
- Internal string app keys (`_apispec_parser`, `_apispec_request_data_name`) removed; `app["swagger_dict"]` kept.

The README "Migration from aiohttp-apispec" section is rewritten into "silent" / "loud" groups with workarounds for each item (the flat-format workaround now points to the built-in `flat_error_handler`); CHANGELOG has an Unreleased entry marking the breaking bits.

### Upgrade impact for existing apigami users

Two changes are breaking for projects already on apigami (both flagged **Breaking** in CHANGELOG), so this should ship as **0.8.0**, not a patch release:

1. `request["data"]` defaults to `{}` instead of `[]` when no schema targets the default key — affects code that compares with `== []`, indexes, or returns the value as-is.
2. An unrecognized `request_schema` keyword argument now raises `TypeError` at decoration (import) time instead of being silently ignored — loud, and exposes a latent bug, but a previously "working" deploy will fail fast.

Edge case: code that already passed `locations=["querystring"]` silently parsed `json` before; it now parses `querystring` (the intended behavior) and emits a `DeprecationWarning`.

### Tests

- `tests/decorators/test_apispec_compat.py`: alias identity, `locations=` shim + `DeprecationWarning`, empty/multi-element and both-args `ValueError`, non-list `TypeError`, unknown-kwarg `TypeError`, `required=` still accepted.
- `tests/test_flat_error_handler.py`: location level stripped, multi-location merge + logged warning, non-dict messages passthrough, end-to-end 422 with flat body.
- Updated `test_match_info` for the `{}` default.
- Full suite: 193 passed; mypy and pre-commit (ruff, codespell) clean.