### PR TITLE
Add callable objects as a schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Support for callable objects ("schema builders") as a schema type: `request_schema` / `response_schema` now accept any callable that returns a `marshmallow.Schema` instance when called with no arguments, alongside `Schema` classes/instances and dataclasses. Resolves [#41](https://github.com/anna-money/aiohttp-apigami/issues/41) ([#123](https://github.com/anna-money/aiohttp-apigami/pull/123)).
+
 ## [0.8.0] - 2026-06-12
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Think of **aiohttp-apigami** as the bridge between your aiohttp web services and
 - **Built-in Swagger UI**: Ready-to-use interactive documentation (currently <!-- SWAGGER_UI_VERSION_START -->[v5.32.6](https://github.com/swagger-api/swagger-ui/releases/tag/v5.32.6)<!-- SWAGGER_UI_VERSION_END -->)
 - **Class-Based View Support**: Fully compatible with aiohttp's CBV pattern
 - **Dataclass Support**: Use Python dataclasses directly as schemas for cleaner code
+- **Schema Builders**: Pass a callable that builds a `Schema` instance for custom construction
 
 > 💡 **aiohttp-apigami** builds upon the foundation of `aiohttp-apispec` (no longer maintained), with inspiration from the `flask-apispec` library.
 
@@ -350,6 +351,46 @@ This pattern is particularly useful for:
 - **Type safety**: Get proper type checking for response data
 - **Code reusability**: Define the wrapper once, use with different data types
 - **Better documentation**: Generic types are properly reflected in OpenAPI/Swagger docs
+
+## 🏭 Schema Builders (callable schemas)
+
+Besides a `Schema` class/instance or a dataclass, you can pass any **callable
+object that returns a `Schema` instance** when called with no arguments. This
+is handy when the schema needs custom construction — for example a
+marshmallow-recipe schema with a specific naming case:
+
+```python
+import marshmallow as m
+import marshmallow_recipe as mr
+from dataclasses import dataclass
+from aiohttp import web
+from aiohttp_apigami import request_schema
+
+
+@dataclass
+class RequestData:
+    id: int
+    name: str
+
+
+class SchemaBuilder:
+    def __init__(self, data_cls: type) -> None:
+        self._data_cls = data_cls
+
+    def __call__(self) -> m.Schema:
+        return mr.schema(self._data_cls, naming_case=mr.CAPITAL_CAMEL_CASE)
+
+
+@request_schema(SchemaBuilder(RequestData))
+async def dataclass_handler(request: web.Request):
+    data: RequestData = request["data"]
+    return web.json_response({"message": "Success", "data": {"id": data.id, "name": data.name}})
+```
+
+The builder is invoked once, at decoration time, and the resulting schema is
+used for both validation and OpenAPI documentation. A plain `lambda: MySchema()`
+works too. The callable must return a `marshmallow.Schema` instance; anything
+else raises a `ValueError`.
 
 ## 🛡️ Custom Error Handling
 

--- a/aiohttp_apigami/decorators/request.py
+++ b/aiohttp_apigami/decorators/request.py
@@ -4,7 +4,7 @@ from collections.abc import Callable
 from functools import partial
 from typing import Any, Literal, TypeVar
 
-from aiohttp_apigami.typedefs import HandlerType, IDataclass, SchemaType
+from aiohttp_apigami.typedefs import HandlerType, IDataclass, SchemaBuilder, SchemaType
 from aiohttp_apigami.utils import get_or_set_apispec, get_or_set_schemas, resolve_schema_instance
 from aiohttp_apigami.validation import ValidationSchema
 
@@ -69,7 +69,7 @@ def _resolve_location(location: ValidLocations, kwargs: dict[str, Any]) -> Valid
 
 
 def request_schema(
-    schema: SchemaType | type[TDataclass],
+    schema: SchemaType | type[TDataclass] | SchemaBuilder,
     location: ValidLocations = _UNSET,
     put_into: str | None = None,
     example: dict[str, Any] | None = None,
@@ -129,9 +129,11 @@ def request_schema(
 
     Parameters
     ----------
-    schema : Schema or dataclass
+    schema : Schema, dataclass or callable
         :class:`Schema <marshmallow.Schema>` class or instance,
-        or a Python dataclass. When using dataclasses, the
+        a Python dataclass, or a callable object (``SchemaBuilder``)
+        that returns a :class:`Schema <marshmallow.Schema>` instance
+        when called with no arguments. When using dataclasses, the
         marshmallow-recipe package is required.
 
     location : str, default="json"

--- a/aiohttp_apigami/decorators/response.py
+++ b/aiohttp_apigami/decorators/response.py
@@ -1,7 +1,7 @@
 from collections.abc import Callable
 from typing import TypeVar
 
-from aiohttp_apigami.typedefs import HandlerType, IDataclass, SchemaType
+from aiohttp_apigami.typedefs import HandlerType, IDataclass, SchemaBuilder, SchemaType
 from aiohttp_apigami.utils import get_or_set_apispec, get_or_set_schemas, resolve_schema_instance
 
 T = TypeVar("T", bound=HandlerType)
@@ -9,7 +9,7 @@ TDataclass = TypeVar("TDataclass", bound=IDataclass)
 
 
 def response_schema(
-    schema: SchemaType | type[TDataclass],
+    schema: SchemaType | type[TDataclass] | SchemaBuilder,
     code: int = 200,
     required: bool = False,
     description: str | None = None,
@@ -59,9 +59,11 @@ def response_schema(
 
     Parameters
     ----------
-    schema : Schema or dataclass
+    schema : Schema, dataclass or callable
         :class:`Schema <marshmallow.Schema>` class or instance,
-        or a Python dataclass. When using dataclasses, the
+        a Python dataclass, or a callable object (``SchemaBuilder``)
+        that returns a :class:`Schema <marshmallow.Schema>` instance
+        when called with no arguments. When using dataclasses, the
         marshmallow-recipe package is required.
 
     code : int, default=200

--- a/aiohttp_apigami/typedefs.py
+++ b/aiohttp_apigami/typedefs.py
@@ -12,6 +12,12 @@ SchemaType = type[m.Schema] | m.Schema
 SchemaNameResolver = Callable[[type[m.Schema]], str]
 
 
+class SchemaBuilder(Protocol):
+    """A callable object that builds a marshmallow Schema instance on call."""
+
+    def __call__(self) -> m.Schema: ...
+
+
 class IDataclass(Protocol):
     __dataclass_fields__: ClassVar[dict[str, dataclasses.Field[Any]]]
 

--- a/aiohttp_apigami/utils.py
+++ b/aiohttp_apigami/utils.py
@@ -63,34 +63,53 @@ def get_or_set_schemas(func: T) -> list[ValidationSchema]:
     return func_schemas
 
 
+def _resolve_schema_class(schema: type[m.Schema]) -> m.Schema:
+    """Instantiate a marshmallow Schema class."""
+    return schema()
+
+
+def _resolve_dataclass(schema: type[TDataclass]) -> m.Schema:
+    """Build a Schema from a dataclass (or a generic alias of one)."""
+    if mr is None:
+        raise RuntimeError(
+            "marshmallow-recipe is required for dataclass support. "
+            "Install it with `pip install aiohttp-apigami[dataclass]`."
+        )
+    return mr.schema(schema)
+
+
+def _resolve_schema_builder(schema: SchemaBuilder) -> m.Schema:
+    """Invoke a callable schema builder and validate its result."""
+    built = schema()
+    if not isinstance(built, m.Schema):
+        raise ValueError(f"Schema builder must return a marshmallow Schema instance, got {type(built).__name__}")
+    return built
+
+
+def _is_dataclass_schema(schema: Any) -> bool:
+    """Check if schema is a dataclass or a generic alias of one.
+
+    For generic aliases like ``MyClass = MyBaseClass[InnerType]``,
+    ``get_origin()`` returns ``MyBaseClass``.
+    """
+    origin = get_origin(schema)
+    return bool(is_dataclass(origin if origin is not None else schema))
+
+
 def resolve_schema_instance(schema: SchemaType | type[TDataclass] | SchemaBuilder) -> m.Schema:
-    if isinstance(schema, type) and issubclass(schema, m.Schema):
-        return schema()
-    if isinstance(schema, m.Schema):
-        return schema
-
-    # Check if schema is a dataclass or a generic alias of a dataclass
-    # For generic aliases like MyClass = MyBaseClass[InnerType], get_origin() returns MyBaseClass
-    schema_to_check = get_origin(schema) if get_origin(schema) is not None else schema
-
-    if is_dataclass(schema_to_check):
-        if mr is None:
-            raise RuntimeError(
-                "marshmallow-recipe is required for dataclass support. "
-                "Install it with `pip install aiohttp-apigami[dataclass]`."
-            )
-        return mr.schema(cast("type[TDataclass]", schema))
-
-    # A callable object (SchemaBuilder) that builds a Schema instance on call.
-    # Checked last so Schema classes and dataclass types (also callable) keep
-    # their dedicated handling above.
-    if callable(schema):
-        built = schema()
-        if not isinstance(built, m.Schema):
-            raise ValueError(f"Schema builder must return a marshmallow Schema instance, got {type(built).__name__}")
-        return built
-
-    raise ValueError(f"Invalid schema type: {schema}")
+    # Dataclass types and callables (Schema classes, builders) all overlap, so
+    # order matters: dedicated types first, the generic callable builder last.
+    match schema:
+        case type() as cls if issubclass(cls, m.Schema):
+            return _resolve_schema_class(cls)
+        case m.Schema():
+            return schema
+        case _ if _is_dataclass_schema(schema):
+            return _resolve_dataclass(cast("type[TDataclass]", schema))
+        case _ if callable(schema):
+            return _resolve_schema_builder(cast("SchemaBuilder", schema))
+        case _:
+            raise ValueError(f"Invalid schema type: {schema}")
 
 
 def make_json_serializable(value: Any) -> Any:

--- a/aiohttp_apigami/utils.py
+++ b/aiohttp_apigami/utils.py
@@ -1,3 +1,4 @@
+import enum
 from dataclasses import is_dataclass
 from decimal import Decimal
 from inspect import isclass
@@ -96,19 +97,41 @@ def _is_dataclass_schema(schema: Any) -> bool:
     return bool(is_dataclass(origin if origin is not None else schema))
 
 
-def resolve_schema_instance(schema: SchemaType | type[TDataclass] | SchemaBuilder) -> m.Schema:
+class _SchemaKind(enum.Enum):
+    """How a value passed as a schema should be resolved into a Schema."""
+
+    SCHEMA_CLASS = enum.auto()
+    SCHEMA_INSTANCE = enum.auto()
+    DATACLASS = enum.auto()
+    BUILDER = enum.auto()
+    INVALID = enum.auto()
+
+
+def _classify_schema(schema: Any) -> _SchemaKind:
     # Dataclass types and callables (Schema classes, builders) all overlap, so
     # order matters: dedicated types first, the generic callable builder last.
-    match schema:
-        case type() as cls if issubclass(cls, m.Schema):
-            return _resolve_schema_class(cls)
-        case m.Schema():
-            return schema
-        case _ if _is_dataclass_schema(schema):
+    if isinstance(schema, type) and issubclass(schema, m.Schema):
+        return _SchemaKind.SCHEMA_CLASS
+    if isinstance(schema, m.Schema):
+        return _SchemaKind.SCHEMA_INSTANCE
+    if _is_dataclass_schema(schema):
+        return _SchemaKind.DATACLASS
+    if callable(schema):
+        return _SchemaKind.BUILDER
+    return _SchemaKind.INVALID
+
+
+def resolve_schema_instance(schema: SchemaType | type[TDataclass] | SchemaBuilder) -> m.Schema:
+    match _classify_schema(schema):
+        case _SchemaKind.SCHEMA_CLASS:
+            return _resolve_schema_class(cast("type[m.Schema]", schema))
+        case _SchemaKind.SCHEMA_INSTANCE:
+            return cast("m.Schema", schema)
+        case _SchemaKind.DATACLASS:
             return _resolve_dataclass(cast("type[TDataclass]", schema))
-        case _ if callable(schema):
+        case _SchemaKind.BUILDER:
             return _resolve_schema_builder(cast("SchemaBuilder", schema))
-        case _:
+        case _:  # _SchemaKind.INVALID
             raise ValueError(f"Invalid schema type: {schema}")
 
 

--- a/aiohttp_apigami/utils.py
+++ b/aiohttp_apigami/utils.py
@@ -2,7 +2,7 @@ from dataclasses import is_dataclass
 from decimal import Decimal
 from inspect import isclass
 from string import Formatter
-from typing import Any, TypeVar, get_origin
+from typing import Any, TypeVar, cast, get_origin
 
 import marshmallow as m
 from aiohttp import web
@@ -10,7 +10,7 @@ from aiohttp.abc import AbstractView
 from aiohttp.typedefs import Handler
 
 from .constants import API_SPEC_ATTR, SCHEMAS_ATTR
-from .typedefs import IDataclass, SchemaType
+from .typedefs import IDataclass, SchemaBuilder, SchemaType
 from .validation import ValidationSchema
 
 try:
@@ -63,7 +63,7 @@ def get_or_set_schemas(func: T) -> list[ValidationSchema]:
     return func_schemas
 
 
-def resolve_schema_instance(schema: SchemaType | type[TDataclass]) -> m.Schema:
+def resolve_schema_instance(schema: SchemaType | type[TDataclass] | SchemaBuilder) -> m.Schema:
     if isinstance(schema, type) and issubclass(schema, m.Schema):
         return schema()
     if isinstance(schema, m.Schema):
@@ -79,7 +79,16 @@ def resolve_schema_instance(schema: SchemaType | type[TDataclass]) -> m.Schema:
                 "marshmallow-recipe is required for dataclass support. "
                 "Install it with `pip install aiohttp-apigami[dataclass]`."
             )
-        return mr.schema(schema)
+        return mr.schema(cast("type[TDataclass]", schema))
+
+    # A callable object (SchemaBuilder) that builds a Schema instance on call.
+    # Checked last so Schema classes and dataclass types (also callable) keep
+    # their dedicated handling above.
+    if callable(schema):
+        built = schema()
+        if not isinstance(built, m.Schema):
+            raise ValueError(f"Schema builder must return a marshmallow Schema instance, got {type(built).__name__}")
+        return built
 
     raise ValueError(f"Invalid schema type: {schema}")
 

--- a/tests/decorators/test_by_builder.py
+++ b/tests/decorators/test_by_builder.py
@@ -1,0 +1,93 @@
+from dataclasses import dataclass
+
+import marshmallow as m
+import marshmallow_recipe as mr
+import pytest
+from aiohttp import web
+from aiohttp.test_utils import TestClient
+from pytest_aiohttp.plugin import AiohttpClient
+
+from aiohttp_apigami import request_schema, response_schema, setup_aiohttp_apispec, validation_middleware
+from aiohttp_apigami.typedefs import IDataclass, SchemaBuilder
+from aiohttp_apigami.validation import ValidationSchema
+
+
+@dataclass
+class RequestData:
+    id: int
+    name: str
+
+
+class CapitalCamelCaseSchemaBuilder:
+    """A callable object that builds a marshmallow Schema (issue #41)."""
+
+    def __init__(self, data_cls: type[IDataclass]) -> None:
+        self._data_cls = data_cls
+
+    def __call__(self) -> m.Schema:
+        return mr.schema(self._data_cls, naming_case=mr.CAPITAL_CAMEL_CASE)
+
+
+def test_request_schema_with_builder() -> None:
+    """request_schema resolves a SchemaBuilder into a Schema instance at decoration time."""
+
+    @request_schema(CapitalCamelCaseSchemaBuilder(RequestData))
+    async def index(request: web.Request) -> web.Response:
+        return web.json_response({})
+
+    assert hasattr(index, "__schemas__")
+    assert len(index.__schemas__) == 1
+    schema = index.__schemas__[0]
+    assert isinstance(schema, ValidationSchema)
+    assert isinstance(schema.schema, m.Schema)
+    # The builder applied CapitalCamelCase naming: attribute names stay snake,
+    # the serialized data_key is CapitalCamelCase.
+    assert set(schema.schema.fields) == {"id", "name"}
+    assert {f.data_key for f in schema.schema.fields.values()} == {"Id", "Name"}
+
+
+def test_response_schema_with_builder() -> None:
+    """response_schema resolves a SchemaBuilder into a Schema instance."""
+
+    @response_schema(CapitalCamelCaseSchemaBuilder(RequestData), 200)
+    async def index(request: web.Request) -> web.Response:
+        return web.json_response({})
+
+    response_spec = index.__apispec__["responses"]["200"]
+    assert isinstance(response_spec["schema"], m.Schema)
+    assert set(response_spec["schema"].fields) == {"id", "name"}
+
+
+def test_builder_satisfies_schema_builder_protocol() -> None:
+    """The builder is structurally a SchemaBuilder."""
+    builder: SchemaBuilder = CapitalCamelCaseSchemaBuilder(RequestData)
+    assert isinstance(builder(), m.Schema)
+
+
+@pytest.fixture
+async def builder_app(aiohttp_client: AiohttpClient) -> TestClient[web.Request, web.Application]:
+    @request_schema(CapitalCamelCaseSchemaBuilder(RequestData))
+    async def handler(request: web.Request) -> web.Response:
+        data: RequestData = request["data"]
+        return web.json_response({"id": data.id, "name": data.name})
+
+    app = web.Application()
+    setup_aiohttp_apispec(app=app)
+    app.middlewares.append(validation_middleware)
+    app.router.add_post("/builder", handler)
+    return await aiohttp_client(app)
+
+
+@pytest.mark.asyncio
+async def test_builder_end_to_end_ok(builder_app: TestClient[web.Request, web.Application]) -> None:
+    """Valid CapitalCamelCase payload is parsed into a dataclass instance."""
+    res = await builder_app.post("/builder", json={"Id": 1, "Name": "max"})
+    assert res.status == 200
+    assert await res.json() == {"id": 1, "name": "max"}
+
+
+@pytest.mark.asyncio
+async def test_builder_end_to_end_validation_error(builder_app: TestClient[web.Request, web.Application]) -> None:
+    """Invalid payload through a builder-produced schema is rejected with 422."""
+    res = await builder_app.post("/builder", json={"Id": "not-an-int", "Name": "max"})
+    assert res.status == 422

--- a/tests/decorators/test_by_builder.py
+++ b/tests/decorators/test_by_builder.py
@@ -53,6 +53,7 @@ def test_response_schema_with_builder() -> None:
     async def index(request: web.Request) -> web.Response:
         return web.json_response({})
 
+    assert hasattr(index, "__apispec__")
     response_spec = index.__apispec__["responses"]["200"]
     assert isinstance(response_spec["schema"], m.Schema)
     assert set(response_spec["schema"].fields) == {"id", "name"}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -283,3 +283,36 @@ class TestResolveSchemaInstance:
         """Test with an invalid schema type."""
         with pytest.raises(ValueError, match="Invalid schema type:"):
             resolve_schema_instance("not a schema")  # type: ignore[arg-type]
+
+    def test_with_schema_builder(self) -> None:
+        """Test with a callable object that builds a Schema instance."""
+
+        class TestSchema(m.Schema):
+            field = m.fields.String()
+
+        class SchemaBuilder:
+            def __call__(self) -> m.Schema:
+                return TestSchema()
+
+        result = resolve_schema_instance(SchemaBuilder())
+        assert isinstance(result, m.Schema)
+        assert isinstance(result, TestSchema)
+
+    def test_with_schema_builder_lambda(self) -> None:
+        """Test with a plain lambda that builds a Schema instance."""
+
+        class TestSchema(m.Schema):
+            field = m.fields.String()
+
+        result = resolve_schema_instance(lambda: TestSchema())
+        assert isinstance(result, TestSchema)
+
+    def test_with_schema_builder_returning_non_schema(self) -> None:
+        """Test with a callable that does not return a Schema instance."""
+
+        class BadBuilder:
+            def __call__(self) -> m.Schema:
+                return "not a schema"  # type: ignore[return-value]
+
+        with pytest.raises(ValueError, match="must return a marshmallow Schema instance"):
+            resolve_schema_instance(BadBuilder())


### PR DESCRIPTION
## Summary
Closes #41. Adds a third way to pass a schema to `request_schema` / `response_schema`: any **callable object that returns a `marshmallow.Schema` instance** when called with no arguments (a "schema builder"). This complements the existing `Schema` class/instance and dataclass support, and is useful when a schema needs custom construction — e.g. a `marshmallow-recipe` schema built with a specific naming case.

```python
class SchemaBuilder:
    def __init__(self, data_cls):
        self._data_cls = data_cls

    def __call__(self) -> m.Schema:
        return mr.schema(self._data_cls, naming_case=mr.CAPITAL_CAMEL_CASE)


@request_schema(SchemaBuilder(RequestData))
async def handler(request):
    data: RequestData = request["data"]
    ...
```

The builder is invoked once, at decoration time; the resulting schema is used for both validation and OpenAPI documentation.

## Changes
- **`typedefs.py`**: add `SchemaBuilder` protocol (`__call__() -> m.Schema`).
- **`utils.py`**: `resolve_schema_instance()` now invokes a callable schema and validates that it returns a `Schema` instance, raising `ValueError` otherwise. Checked after the Schema/dataclass branches so existing types keep their dedicated handling.
- **`decorators/request.py`, `decorators/response.py`**: accept `SchemaBuilder` in the `schema` parameter; docstrings updated.
- **`README.md`**: new "Schema Builders" section and feature bullet.
- **Tests**: unit tests for `resolve_schema_instance` (callable object, lambda, invalid return) and a new `tests/decorators/test_by_builder.py` covering decorator resolution, response schemas, protocol conformance, and end-to-end validation through the middleware (valid payload → dataclass instance; invalid → 422).

All 201 tests pass; `ruff` and `mypy` clean (no new errors).