### PR TITLE
Prepare 0.9.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.0] - 2026-06-19
+
 ### Added
 
 - Support for callable objects ("schema builders") as a schema type: `request_schema` / `response_schema` now accept any callable that returns a `marshmallow.Schema` instance when called with no arguments, alongside `Schema` classes/instances and dataclasses. Resolves [#41](https://github.com/anna-money/aiohttp-apigami/issues/41) ([#123](https://github.com/anna-money/aiohttp-apigami/pull/123)).


### PR DESCRIPTION
## Summary
Stamps CHANGELOG `[0.9.0] - 2026-06-19`. Minor release: one backward-compatible feature, no breaking changes.

## Changes since 0.8.0 (from #123)

### Added
- Callable objects ("schema builders") as a schema type: `request_schema` / `response_schema` now accept any callable returning a `marshmallow.Schema` instance, alongside `Schema` classes/instances and dataclasses. Resolves #41.

## Release steps
After merge, create a GitHub Release for tag `0.9.0` on master (optionally `0.9.0rc1` first to validate) to trigger the PyPI publish workflow.