### PR TITLE
ci: add pi AI code reviewer workflow

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -1,0 +1,21 @@
+name: PR review (pi)
+
+on:
+  pull_request:
+    types: [ opened, reopened, synchronize ]
+    branches: [ master ]
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-review-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  review:
+    uses: anna-money/shared-actions/.github/workflows/pr-review.yml@main
+    with:
+      min-changed-lines: "1"
+    secrets: inherit


### PR DESCRIPTION
### Why

The platform team shipped a shared, automated PR reviewer (powered by pi.dev + GPT 5.5) in `anna-money/shared-actions` and asked teams to opt in. This repo had no AI review on PRs.

### What

Adds an opt-in GitHub Actions workflow that runs the shared reviewer on every PR targeting `master`.

- Reviews the diff for architecture, security, logic, simplicity and code smells; leaves inline comments with concrete suggestions.
- Requests changes only on critical/high findings; otherwise just comments. Advisory and idempotent — re-runs update the same threads.
- `min-changed-lines: "1"` overrides the shared default of `100`, so re-reviews run on effectively every push.
- Azure key/config are org-level secrets/vars inherited via `secrets: inherit` — nothing to wire here.

### How to review

- Only file changed: `.github/workflows/pr-review.yml`.
- The reusable workflow gates to same-repo, non-draft PRs (fork PRs get read-only tokens), so this caller stays minimal.

### Risks / Rollout

- Risk level: Low — advisory workflow, no impact on app code or other CI jobs. A noisy/incorrect review can be dismissed.
- Rollback: delete `.github/workflows/pr-review.yml`.

### Follow-ups

- Tune `min-changed-lines` upward if re-review frequency is too noisy.
