### PR TITLE
chore(deps): batch GitHub Actions bumps (supersedes #128, #131)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: actions/setup-python@v6
+      - uses: actions/setup-python@v7
         with:
           python-version: ${{ env.MIN_PYTHON_VERSION }}
       - uses: pre-commit/action@v3.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -22,4 +22,4 @@ jobs:
         run: |
           uv build --verbose
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@v1.14.0
+        uses: pypa/gh-action-pypi-publish@v1.14.2


### PR DESCRIPTION
Batches two individually green GitHub Actions bumps into one PR so master takes a single build.

No library code touched — workflow files only.

Supersedes:

- #128 — actions/setup-python 6 → 7 (ci.yml)
- #131 — pypa/gh-action-pypi-publish 1.14.0 → 1.14.2 (publish.yml)

Both branches merged with no conflicts; combined diff is exactly the union of the two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)